### PR TITLE
refactor: extract constants

### DIFF
--- a/assembly/constants.ts
+++ b/assembly/constants.ts
@@ -1,0 +1,6 @@
+export const MILLIS_PER_DAY = 1_000 * 60 * 60 * 24;
+export const MILLIS_PER_HOUR = 1_000 * 60 * 60;
+export const MILLIS_PER_MINUTE = 1_000 * 60;
+export const MILLIS_PER_SECOND = 1_000;
+export const MICROS_PER_SECOND = 1_000_000;
+export const NANOS_PER_SECOND = 1_000_000_000;

--- a/assembly/date.ts
+++ b/assembly/date.ts
@@ -2,11 +2,7 @@
 // https://github.com/AssemblyScript/assemblyscript/pull/1768
 
 import { YMD } from "./utils";
-
-const MILLIS_PER_DAY = 1_000 * 60 * 60 * 24;
-const MILLIS_PER_HOUR = 1_000 * 60 * 60;
-const MILLIS_PER_MINUTE = 1_000 * 60;
-const MILLIS_PER_SECOND = 1_000;
+import { MILLIS_PER_DAY, MILLIS_PER_HOUR, MILLIS_PER_MINUTE, MILLIS_PER_SECOND } from "./constants";
 
 export class Date {
   epochMilliseconds: i64;

--- a/assembly/duration.ts
+++ b/assembly/duration.ts
@@ -1,4 +1,5 @@
 import { durationSign } from "./utils";
+import { MICROS_PER_SECOND, MILLIS_PER_SECOND, NANOS_PER_SECOND } from "./constants";
 
 export class DurationLike {
   years: i32 = 0;
@@ -70,9 +71,9 @@ export class Duration {
       toString(this.minutes, "M") +
       toString(
         // sort in ascending order for better sum precision
-        f64(this.nanoseconds) / 1000000000.0 +
-          f64(this.microseconds) / 1000000.0 +
-          f64(this.milliseconds) / 1000.0 +
+        f64(this.nanoseconds) / NANOS_PER_SECOND +
+          f64(this.microseconds) / MICROS_PER_SECOND +
+          f64(this.milliseconds) / MILLIS_PER_SECOND +
           f64(this.seconds),
         "S"
       );

--- a/assembly/plaindatetime.ts
+++ b/assembly/plaindatetime.ts
@@ -2,6 +2,7 @@ import { RegExp } from "../node_modules/assemblyscript-regex/assembly/index";
 
 import { Duration, DurationLike } from "./duration";
 import { Overflow, TimeComponent } from "./enums";
+import { MICROS_PER_SECOND, MILLIS_PER_SECOND, NANOS_PER_SECOND } from "./constants";
 import {
   dayOfWeek,
   dayOfYear,
@@ -183,9 +184,9 @@ export class PlainDateTime {
        this.microsecond != 0 ||
        this.millisecond != 0
         ? (
-            f64(this.nanosecond)  / 1_000_000_000.0 +
-            f64(this.microsecond) / 1_000_000.0 +
-            f64(this.millisecond) / 1_000.0
+            f64(this.nanosecond)  / NANOS_PER_SECOND +
+            f64(this.microsecond) / MICROS_PER_SECOND +
+            f64(this.millisecond) / MILLIS_PER_SECOND
           ).toString().substring(1)
         : ""
       )

--- a/assembly/utils.ts
+++ b/assembly/utils.ts
@@ -8,6 +8,7 @@
 
 import { Duration } from "./duration";
 import { Overflow, TimeComponent } from "./enums";
+import { MILLIS_PER_SECOND, NANOS_PER_SECOND } from "./constants";
 import { log } from "./env";
 
 const YEAR_MIN = -271821;
@@ -350,13 +351,13 @@ function totalDurationNanoseconds(
   hours += days * 24;
   minutes += hours * 60;
   seconds += minutes * 60;
-  milliseconds += seconds * 1000;
+  milliseconds += seconds * MILLIS_PER_SECOND;
   microseconds += milliseconds * 1000;
   return nanoseconds + microseconds * 1000;
 }
 
 function nanosecondsToDays(ns: i64): NanoDays {
-  const oneDayNs: i64 = 24 * 60 * 60 * 1_000_000_000;
+  const oneDayNs: i64 = 24 * 60 * 60 * NANOS_PER_SECOND;
   return ns == 0
     ? { days: 0, nanoseconds: 0, dayLengthNs: oneDayNs }
     : {
@@ -417,7 +418,7 @@ export function balanceDuration(
       milliseconds = microseconds / 1000;
       microseconds = microseconds % 1000;
 
-      seconds      = milliseconds / 1000;
+      seconds      = milliseconds / MILLIS_PER_SECOND;
       milliseconds = milliseconds % 1000;
 
       minutes = seconds / 60;
@@ -434,7 +435,7 @@ export function balanceDuration(
       milliseconds = microseconds / 1000;
       microseconds = microseconds % 1000;
 
-      seconds      = milliseconds / 1000;
+      seconds      = milliseconds / MILLIS_PER_SECOND;
       milliseconds = milliseconds % 1000;
 
       minutes = seconds / 60;
@@ -448,7 +449,7 @@ export function balanceDuration(
       milliseconds = microseconds / 1000;
       microseconds = microseconds % 1000;
 
-      seconds      = milliseconds / 1000;
+      seconds      = milliseconds / MILLIS_PER_SECOND;
       milliseconds = milliseconds % 1000;
       break;
 


### PR DESCRIPTION
I don't know how useful this would be, but there are a lot of constants, that can be extracted.

A few downsides I could see are:
* is either float **or** int and we would need some of them as both types to reduce implicit casting (if the compile can't do that at compile time)
* I don't know how well those constants can be inlined