### PR TITLE
Implement PlainTime

### DIFF
--- a/assembly/__tests__/plaintime.spec.ts
+++ b/assembly/__tests__/plaintime.spec.ts
@@ -1,7 +1,8 @@
 import { Duration, DurationLike } from "../duration";
-import { PlainTime } from "../plaintime";
+import { PlainDateTime } from "../plaindatetime";
+import { PlainTime, TimeLike } from "../plaintime";
 
-let time: PlainTime;
+let time: PlainTime, t1: PlainTime, t2: PlainTime, t3: PlainTime;
 
 describe("Construction", () => {
   describe("complete", () => {
@@ -26,8 +27,8 @@ describe("Construction", () => {
     });
     // it("time.calendar.id is iso8601", () =>
     //   expect(time.calendar.id).toBe("iso8601"));
-    // it("`${time}` is 15:23:30.123456789", () =>
-    //   expect(`${time}`).toBe("15:23:30.123456789"));
+    // it("time}` is 15:23:30.123456789", () =>
+    //   expect(time}`).toBe("15:23:30.123456789"));
   });
   describe("missing nanosecond", () => {
     time = new PlainTime(15, 23, 30, 123, 456);
@@ -49,8 +50,8 @@ describe("Construction", () => {
     it("time.nanosecond is 0", () => {
       expect(time.nanosecond).toBe(0);
     });
-    // it("`${time}` is 15:23:30.123456", () => {
-    //   expect(`${time}`).toBe("15:23:30.123456");
+    // it("time}` is 15:23:30.123456", () => {
+    //   expect(time}`).toBe("15:23:30.123456");
     // });
   });
   describe("missing microsecond", () => {
@@ -73,8 +74,8 @@ describe("Construction", () => {
     it("time.nanosecond is 0", () => {
       expect(time.nanosecond).toBe(0);
     });
-    // it("`${time}` is 15:23:30.123", () => {
-    //   expect(`${time}`).toBe("15:23:30.123");
+    // it("time}` is 15:23:30.123", () => {
+    //   expect(time}`).toBe("15:23:30.123");
     // });
   });
   describe("missing millisecond", () => {
@@ -97,7 +98,7 @@ describe("Construction", () => {
     it("time.nanosecond is 0", () => {
       expect(time.nanosecond).toBe(0);
     });
-    // it("`${time}` is 15:23:30", () => equal(`${time}`, "15:23:30"));
+    // it("time}` is 15:23:30", () => expect(time).toBe( "15:23:30"));
   });
   describe("missing second", () => {
     time = new PlainTime(15, 23);
@@ -119,47 +120,664 @@ describe("Construction", () => {
     it("time.nanosecond is 0", () => {
       expect(time.nanosecond).toBe(0);
     });
-    // it("`${time}` is 15:23:00", () => equal(`${time}`, "15:23:00"));
+    // it("time}` is 15:23:00", () => expect(time).toBe( "15:23:00"));
   });
   describe("missing minute", () => {
     const time = new PlainTime(15);
-    // it("`${time}` is 15:00:00", () => equal(`${time}`, "15:00:00"));
+    // it("time}` is 15:00:00", () => expect(time).toBe( "15:00:00"));
   });
   describe("missing all parameters", () => {
     const time = new PlainTime();
-    // it("`${time}` is 00:00:00", () => equal(`${time}`, "00:00:00"));
+    // it("time}` is 00:00:00", () => expect(time).toBe( "00:00:00"));
   });
 });
 
-// describe('Time.compare() works', () => {
-//   const t1 = PlainTime.from('08:44:15.321');
-//   const t2 = PlainTime.from('14:23:30.123');
-//   it('equal', () => equal(PlainTime.compare(t1, t1), 0));
-//   it('smaller/larger', () => equal(PlainTime.compare(t1, t2), -1));
-//   it('larger/smaller', () => equal(PlainTime.compare(t2, t1), 1));
-//   it('casts first argument', () => {
-//     equal(PlainTime.compare({ hour: 16, minute: 34 }, t2), 1);
-//     equal(PlainTime.compare('16:34', t2), 1);
-//   });
-//   it('casts second argument', () => {
-//     equal(PlainTime.compare(t1, { hour: 16, minute: 34 }), -1);
-//     equal(PlainTime.compare(t1, '16:34'), -1);
-//   });
-//   it('object must contain at least one correctly-spelled property', () => {
-//     throws(() => PlainTime.compare({ hours: 16 }, t2), TypeError);
-//     throws(() => PlainTime.compare(t1, { hours: 16 }), TypeError);
-//   });
-// });
-// describe('time.equals() works', () => {
-//   const t1 = PlainTime.from('08:44:15.321');
-//   const t2 = PlainTime.from('14:23:30.123');
-//   it('equal', () => assert(t1.equals(t1)));
-//   it('unequal', () => assert(!t1.equals(t2)));
-//   it('casts argument', () => {
-//     assert(t1.equals('08:44:15.321'));
-//     assert(t1.equals({ hour: 8, minute: 44, second: 15, millisecond: 321 }));
-//   });
-//   it('object must contain at least one correctly-spelled property', () => {
-//     throws(() => t1.equals({ hours: 8 }), TypeError);
-//   });
-// });
+describe("Time.compare() works", () => {
+  t1 = PlainTime.from("08:44:15.321");
+  t2 = PlainTime.from("14:23:30.123");
+  it("equal", () => {
+    expect(PlainTime.compare(t1, t1)).toBe(0);
+  });
+  it("smaller/larger", () => {
+    expect(PlainTime.compare(t1, t2)).toBe(-1);
+  });
+  it("larger/smaller", () => {
+    expect(PlainTime.compare(t2, t1)).toBe(1);
+  });
+  // it("casts first argument", () => {
+  //   expect(PlainTime.compare({ hour: 16, minute: 34 }, t2), 1);
+  //   expect(PlainTime.compare("16:34", t2), 1);
+  // });
+  // it("casts second argument", () => {
+  //   expect(PlainTime.compare(t1, { hour: 16, minute: 34 }), -1);
+  //   expect(PlainTime.compare(t1, "16:34"), -1);
+  // });
+  // it("object must contain at least one correctly-spelled property", () => {
+  //   throws(() => PlainTime.compare({ hours: 16 }, t2), TypeError);
+  //   throws(() => PlainTime.compare(t1, { hours: 16 }), TypeError);
+  // });
+});
+
+describe("time.equals() works", () => {
+  t1 = PlainTime.from("08:44:15.321");
+  t2 = PlainTime.from("14:23:30.123");
+  it("equal", () => {
+    expect(t1).toBe(t1);
+  });
+  it("unequal", () => {
+    expect(t2).not.toBe(t1);
+  });
+  // it("casts argument", () => {
+  //   assert(t1.equals("08:44:15.321"));
+  //   assert(t1.equals({ hour: 8, minute: 44, second: 15, millisecond: 321 }));
+  // });
+  // it("object must contain at least one correctly-spelled property", () => {
+  //   throws(() => t1.equals({ hours: 8 }), TypeError);
+  // });
+});
+
+describe("time.add() works", () => {
+  time = new PlainTime(15, 23, 30, 123, 456, 789);
+  it(time.toString() + ".add({ hours: 16 })", () => {
+    log(time.second);
+
+    expect(
+      time
+        .add<DurationLike>({ hours: 16 })
+        .toString()
+    ).toBe("07:23:30.123456789");
+  });
+  it(time.toString() + ".add({ minutes: 45 })", () => {
+    expect(
+      time
+        .add<DurationLike>({ minutes: 45 })
+        .toString()
+    ).toBe("16:08:30.123456789");
+  });
+  it(time.toString() + ".add({ nanoseconds: 300 })", () => {
+    expect(
+      time
+        .add<DurationLike>({ nanoseconds: 300 })
+        .toString()
+    ).toBe("15:23:30.123457089");
+  });
+  it("symmetric with regard to negative durations", () => {
+    expect(
+      PlainTime.from<string>("07:23:30.123456789")
+        .add<DurationLike>({ hours: -16 })
+        .toString()
+    ).toBe("15:23:30.123456789");
+    expect(
+      PlainTime.from<string>("16:08:30.123456789")
+        .add<DurationLike>({ minutes: -45 })
+        .toString()
+    ).toBe("15:23:30.123456789");
+    expect(
+      PlainTime.from<string>("15:23:30.123457089")
+        .add<DurationLike>({ nanoseconds: -300 })
+        .toString()
+    ).toBe("15:23:30.123456789");
+  });
+  // it("time.add(durationObj)", () => {
+  //   expect(time.add(Duration.from("PT16H")).toString()).toBe(
+  //     "07:23:30.123456789"
+  //   );
+  // });
+  // it("casts argument", () =>
+  //   expect(time.add("PT16H").toString()).toBe("07:23:30.123456789"));
+  // it("ignores higher units", () => {
+  //   expect(time.add({ days: 1 }).toString()).toBe("15:23:30.123456789");
+  //   expect(time.add({ months: 1 }).toString()).toBe("15:23:30.123456789");
+  //   expect(time.add({ years: 1 }).toString()).toBe("15:23:30.123456789");
+  // });
+  // it("mixed positive and negative values always throw", () => {
+  //   ["constrain", "reject"].forEach((overflow) =>
+  //     throws(
+  //       () => time.add({ hours: 1, minutes: -30 }, { overflow }),
+  //       RangeError
+  //     )
+  //   );
+  // });
+  // it("options is ignored", () => {
+  //   [
+  //     null,
+  //     1,
+  //     "hello",
+  //     true,
+  //     Symbol("foo"),
+  //     1n,
+  //     {},
+  //     () => {},
+  //     undefined,
+  //   ].forEach((options) =>
+  //     expect(time.add({ hours: 1 }, options).toString()).toBe(
+  //       "16:23:30.123456789"
+  //     )
+  //   );
+  //   ["", "CONSTRAIN", "balance", 3, null].forEach((overflow) =>
+  //     expect(time.add({ hours: 1 }, { overflow }).toString()).toBe(
+  //       "16:23:30.123456789"
+  //     )
+  //   );
+  // });
+  // it("object must contain at least one correctly-spelled property", () => {
+  //   throws(() => time.add({}), TypeError);
+  //   throws(() => time.add({ minute: 12 }), TypeError);
+  // });
+  // it("incorrectly-spelled properties are ignored", () => {
+  //   expect(time.add({ minute: 1, hours: 1 }).toString()).toBe(
+  //     "16:23:30.123456789"
+  //   );
+  // });
+});
+
+describe("time.subtract() works", () => {
+  time = PlainTime.from("15:23:30.123456789");
+  it(time.toString() + ".subtract({ hours: 16 })", () => {
+    expect(
+      time
+        .subtract<DurationLike>({ hours: 16 })
+        .toString()
+    ).toBe("23:23:30.123456789");
+  });
+  it(time.toString() + ".subtract({ minutes: 45 })", () => {
+    expect(
+      time
+        .subtract<DurationLike>({ minutes: 45 })
+        .toString()
+    ).toBe("14:38:30.123456789");
+  });
+  it(time.toString() + ".subtract({ seconds: 45 })", () => {
+    expect(
+      time
+        .subtract<DurationLike>({ seconds: 45 })
+        .toString()
+    ).toBe("15:22:45.123456789");
+  });
+  it(time.toString() + ".subtract({ milliseconds: 800 })", () => {
+    expect(
+      time
+        .subtract<DurationLike>({ milliseconds: 800 })
+        .toString()
+    ).toBe("15:23:29.323456789");
+  });
+  it(time.toString() + ".subtract({ microseconds: 800 })", () => {
+    expect(
+      time
+        .subtract<DurationLike>({ microseconds: 800 })
+        .toString()
+    ).toBe("15:23:30.122656789");
+  });
+  it(time.toString() + ".subtract({ nanoseconds: 800 })", () => {
+    expect(
+      time
+        .subtract<DurationLike>({ nanoseconds: 800 })
+        .toString()
+    ).toBe("15:23:30.123455989");
+  });
+  it("symmetric with regard to negative durations", () => {
+    expect(
+      PlainTime.from("23:23:30.123456789")
+        .subtract<DurationLike>({ hours: -16 })
+        .toString()
+    ).toBe("15:23:30.123456789");
+    expect(
+      PlainTime.from("14:38:30.123456789")
+        .subtract<DurationLike>({ minutes: -45 })
+        .toString()
+    ).toBe("15:23:30.123456789");
+    expect(
+      PlainTime.from("15:22:45.123456789")
+        .subtract<DurationLike>({ seconds: -45 })
+        .toString()
+    ).toBe("15:23:30.123456789");
+    expect(
+      PlainTime.from("15:23:29.323456789")
+        .subtract<DurationLike>({ milliseconds: -800 })
+        .toString()
+    ).toBe("15:23:30.123456789");
+    expect(
+      PlainTime.from("15:23:30.122656789")
+        .subtract<DurationLike>({ microseconds: -800 })
+        .toString()
+    ).toBe("15:23:30.123456789");
+    expect(
+      PlainTime.from("15:23:30.123455989")
+        .subtract<DurationLike>({ nanoseconds: -800 })
+        .toString()
+    ).toBe("15:23:30.123456789");
+  });
+  // it("time.subtract(durationObj)", () => {
+  //   expect(time.subtract(Temporal.Duration.from("PT16H")).toString()).toBe(
+  //     "23:23:30.123456789"
+  //   );
+  // });
+  // it("casts argument", () =>
+  //   expect(time.subtract("PT16H").toString()).toBe("23:23:30.123456789"));
+  it("ignores higher units", () => {
+    expect(
+      time
+        .subtract<DurationLike>({ days: 1 })
+        .toString()
+    ).toBe("15:23:30.123456789");
+    expect(
+      time
+        .subtract<DurationLike>({ months: 1 })
+        .toString()
+    ).toBe("15:23:30.123456789");
+    expect(
+      time
+        .subtract<DurationLike>({ years: 1 })
+        .toString()
+    ).toBe("15:23:30.123456789");
+  });
+  // it("mixed positive and negative values always throw", () => {
+  //   ["constrain", "reject"].forEach((overflow) =>
+  //     throws(
+  //       () => time.subtract({ hours: 1, minutes: -30 }, { overflow }),
+  //       RangeError
+  //     )
+  //   );
+  // });
+  // it("options is ignored", () => {
+  //   [
+  //     null,
+  //     1,
+  //     "hello",
+  //     true,
+  //     Symbol("foo"),
+  //     1n,
+  //     {},
+  //     () => {},
+  //     undefined,
+  //   ].forEach((options) =>
+  //     expect(time.subtract({ hours: 1 }, options).toString()).toBe(
+  //       "14:23:30.123456789"
+  //     )
+  //   );
+  //   ["", "CONSTRAIN", "balance", 3, null].forEach((overflow) =>
+  //     expect(time.subtract({ hours: 1 }, { overflow }).toString()).toBe(
+  //       "14:23:30.123456789"
+  //     )
+  //   );
+  // });
+  // it("object must contain at least one correctly-spelled property", () => {
+  //   throws(() => time.subtract({}), TypeError);
+  //   throws(() => time.subtract({ minute: 12 }), TypeError);
+  // });
+  // it("incorrectly-spelled properties are ignored", () => {
+  //   expect(time.subtract({ minute: 1, hours: 1 }).toString()).toBe(
+  //     "14:23:30.123456789"
+  //   );
+  // });
+});
+
+describe("time.toString() works", () => {
+  it("new Time(15, 23).toString()", () => {
+    expect(new PlainTime(15, 23).toString()).toBe("15:23:00");
+  });
+  it("new Time(15, 23, 30).toString()", () => {
+    expect(new PlainTime(15, 23, 30).toString()).toBe("15:23:30");
+  });
+  it("new Time(15, 23, 30, 123).toString()", () => {
+    expect(new PlainTime(15, 23, 30, 123).toString()).toBe("15:23:30.123");
+  });
+  it("new Time(15, 23, 30, 123, 456).toString()", () => {
+    expect(new PlainTime(15, 23, 30, 123, 456).toString()).toBe(
+      "15:23:30.123456"
+    );
+  });
+  it("new Time(15, 23, 30, 123, 456, 789).toString()", () => {
+    expect(new PlainTime(15, 23, 30, 123, 456, 789).toString()).toBe(
+      "15:23:30.123456789"
+    );
+  });
+  t1 = PlainTime.from("15:23");
+  t2 = PlainTime.from("15:23:30");
+  t3 = PlainTime.from("15:23:30.1234");
+  it("default is to emit seconds and drop trailing zeros after the decimal", () => {
+    expect(t1.toString()).toBe("15:23:00");
+    expect(t2.toString()).toBe("15:23:30");
+    expect(t3.toString()).toBe("15:23:30.1234");
+  });
+  // it("truncates to minute", () => {
+  //   [t1, t2, t3].forEach((t) =>
+  //     expect(t.toString({ smallestUnit: "minute" }), "15:23")
+  //   );
+  // });
+  // it("other smallestUnits are aliases for fractional digits", () => {
+  //   expect(
+  //     t3.toString({ smallestUnit: "second" }),
+  //     t3.toString({ fractionalSecondDigits: 0 })
+  //   );
+  //   expect(
+  //     t3.toString({ smallestUnit: "millisecond" }),
+  //     t3.toString({ fractionalSecondDigits: 3 })
+  //   );
+  //   expect(
+  //     t3.toString({ smallestUnit: "microsecond" }),
+  //     t3.toString({ fractionalSecondDigits: 6 })
+  //   );
+  //   expect(
+  //     t3.toString({ smallestUnit: "nanosecond" }),
+  //     t3.toString({ fractionalSecondDigits: 9 })
+  //   );
+  // });
+  // it("throws on invalid or disallowed smallestUnit", () => {
+  //   [
+  //     "era",
+  //     "year",
+  //     "month",
+  //     "day",
+  //     "hour",
+  //     "nonsense",
+  //   ].forEach((smallestUnit) =>
+  //     throws(() => t1.toString({ smallestUnit }), RangeError)
+  //   );
+  // });
+  // it("accepts plural units", () => {
+  //   expect(
+  //     t3.toString({ smallestUnit: "minutes" }),
+  //     t3.toString({ smallestUnit: "minute" })
+  //   );
+  //   expect(
+  //     t3.toString({ smallestUnit: "seconds" }),
+  //     t3.toString({ smallestUnit: "second" })
+  //   );
+  //   expect(
+  //     t3.toString({ smallestUnit: "milliseconds" }),
+  //     t3.toString({ smallestUnit: "millisecond" })
+  //   );
+  //   expect(
+  //     t3.toString({ smallestUnit: "microseconds" }),
+  //     t3.toString({ smallestUnit: "microsecond" })
+  //   );
+  //   expect(
+  //     t3.toString({ smallestUnit: "nanoseconds" }),
+  //     t3.toString({ smallestUnit: "nanosecond" })
+  //   );
+  // });
+  // it("truncates or pads to 2 places", () => {
+  //   const options = { fractionalSecondDigits: 2 };
+  //   expect(t1.toString(options), "15:23:00.00");
+  //   expect(t2.toString(options), "15:23:30.00");
+  //   expect(t3.toString(options), "15:23:30.12");
+  // });
+  // it("pads to 7 places", () => {
+  //   const options = { fractionalSecondDigits: 7 };
+  //   expect(t1.toString(options), "15:23:00.0000000");
+  //   expect(t2.toString(options), "15:23:30.0000000");
+  //   expect(t3.toString(options), "15:23:30.1234000");
+  // });
+  // it("auto is the default", () => {
+  //   [t1, t2, t3].forEach((dt) =>
+  //     expect(dt.toString({ fractionalSecondDigits: "auto" }), dt.toString())
+  //   );
+  // });
+  // it("throws on out of range or invalid fractionalSecondDigits", () => {
+  //   [-1, 10, Infinity, NaN, "not-auto"].forEach((fractionalSecondDigits) =>
+  //     throws(() => t1.toString({ fractionalSecondDigits }), RangeError)
+  //   );
+  // });
+  // it("accepts and truncates fractional fractionalSecondDigits", () => {
+  //   expect(t3.toString({ fractionalSecondDigits: 5.5 }), "15:23:30.12340");
+  // });
+  // it("smallestUnit overrides fractionalSecondDigits", () => {
+  //   expect(
+  //     t3.toString({ smallestUnit: "minute", fractionalSecondDigits: 9 }),
+  //     "15:23"
+  //   );
+  // });
+  // it("throws on invalid roundingMode", () => {
+  //   throws(() => t1.toString({ roundingMode: "cile" }), RangeError);
+  // });
+  // it("rounds to nearest", () => {
+  //   expect(
+  //     t2.toString({ smallestUnit: "minute", roundingMode: "halfExpand" }),
+  //     "15:24"
+  //   );
+  //   expect(
+  //     t3.toString({ fractionalSecondDigits: 3, roundingMode: "halfExpand" }),
+  //     "15:23:30.123"
+  //   );
+  // });
+  // it("rounds up", () => {
+  //   expect(
+  //     t2.toString({ smallestUnit: "minute", roundingMode: "ceil" }),
+  //     "15:24"
+  //   );
+  //   expect(
+  //     t3.toString({ fractionalSecondDigits: 3, roundingMode: "ceil" }),
+  //     "15:23:30.124"
+  //   );
+  // });
+  // it("rounds down", () => {
+  //   ["floor", "trunc"].forEach((roundingMode) => {
+  //     expect(t2.toString({ smallestUnit: "minute", roundingMode }), "15:23");
+  //     expect(
+  //       t3.toString({ fractionalSecondDigits: 3, roundingMode }),
+  //       "15:23:30.123"
+  //     );
+  //   });
+  // });
+  // it("rounding can affect all units", () => {
+  //   const t4 = PlainTime.from("23:59:59.999999999");
+  //   expect(
+  //     t4.toString({ fractionalSecondDigits: 8, roundingMode: "halfExpand" }),
+  //     "00:00:00.00000000"
+  //   );
+  // });
+  // it("options may only be an object or undefined", () => {
+  //   [null, 1, "hello", true, Symbol("foo"), 1n].forEach((badOptions) =>
+  //     throws(() => t1.toString(badOptions), TypeError)
+  //   );
+  //   [{}, () => {}, undefined].forEach((options) =>
+  //     expect(t1.toString(options), "15:23:00")
+  //   );
+  // });
+});
+
+describe("Time.from() works", () => {
+  it('Time.from("15:23")', () => {
+    expect(PlainTime.from("15:23").toString()).toBe("15:23:00");
+  });
+  it('Time.from("15:23:30")', () => {
+    expect(PlainTime.from("15:23:30").toString()).toBe("15:23:30");
+  });
+  it('Time.from("15:23:30.123")', () => {
+    expect(PlainTime.from("15:23:30.123").toString()).toBe("15:23:30.123");
+  });
+  it('Time.from("15:23:30.123456")', () => {
+    expect(PlainTime.from("15:23:30.123456").toString()).toBe(
+      "15:23:30.123456"
+    );
+  });
+  it('Time.from("15:23:30.123456789")', () => {
+    expect(PlainTime.from("15:23:30.123456789").toString()).toBe(
+      "15:23:30.123456789"
+    );
+  });
+  it("Time.from({ hour: 15, minute: 23 })", () => {
+    expect(
+      PlainTime.from<TimeLike>({
+        hour: 15,
+        minute: 23,
+        second: 0,
+        microsecond: 0,
+        millisecond: 0,
+        nanosecond: 0,
+      }).toString()
+    ).toBe("15:23:00");
+  });
+  it("Time.from({ minute: 30, microsecond: 555 })", () => {
+    expect(PlainTime.from({ minute: 30, microsecond: 555 }).toString()).toBe(
+      "00:30:00.000555"
+    );
+  });
+  it("Time.from(ISO string leap second) is constrained", () => {
+    expect(PlainTime.from("23:59:60").toString()).toBe("23:59:59");
+    expect(PlainTime.from("23:59:60").toString()).toBe("23:59:59");
+  });
+  // it("Time.from(number) is converted to string", () => {
+  //   expect(PlainTime.from(152343).toString()).toBe(
+  //     PlainTime.from("152343").toString()
+  //   );
+  // });
+  it("Time.from(time) returns the same properties", () => {
+    const t = PlainTime.from("2020-02-12T11:42:00+01:00[Europe/Amsterdam]");
+    expect(PlainTime.from(t).toString()).toBe(t.toString());
+  });
+  it("Time.from(dateTime) returns the same time properties", () => {
+    const dt = PlainDateTime.from(
+      "2020-02-12T11:42:00+01:00[Europe/Amsterdam]"
+    );
+    expect(PlainTime.from(dt).toString()).toBe(dt.toPlainTime().toString());
+  });
+  it("Time.from(time) is not the same object", () => {
+    const t = PlainTime.from("2020-02-12T11:42:00+01:00[Europe/Amsterdam]");
+    expect(PlainTime.from(t)).not.toBe(t);
+  });
+  it("any number of decimal places", () => {
+    expect(PlainTime.from("1976-11-18T15:23:30.1Z").toString()).toBe(
+      "15:23:30.1"
+    );
+    expect(PlainTime.from("1976-11-18T15:23:30.12Z").toString()).toBe(
+      "15:23:30.12"
+    );
+    expect(PlainTime.from("1976-11-18T15:23:30.123Z").toString()).toBe(
+      "15:23:30.123"
+    );
+    expect(PlainTime.from("1976-11-18T15:23:30.1234Z").toString()).toBe(
+      "15:23:30.1234"
+    );
+    expect(PlainTime.from("1976-11-18T15:23:30.12345Z").toString()).toBe(
+      "15:23:30.12345"
+    );
+    expect(PlainTime.from("1976-11-18T15:23:30.123456Z").toString()).toBe(
+      "15:23:30.123456"
+    );
+    expect(PlainTime.from("1976-11-18T15:23:30.1234567Z").toString()).toBe(
+      "15:23:30.1234567"
+    );
+    expect(PlainTime.from("1976-11-18T15:23:30.12345678Z").toString()).toBe(
+      "15:23:30.12345678"
+    );
+    expect(PlainTime.from("1976-11-18T15:23:30.123456789Z").toString()).toBe(
+      "15:23:30.123456789"
+    );
+  });
+  it("variant decimal separator", () => {
+    expect(PlainTime.from("1976-11-18T15:23:30,12Z").toString()).toBe(
+      "15:23:30.12"
+    );
+  });
+  // it("variant minus sign", () => {
+  //   expect(PlainTime.from("1976-11-18T15:23:30.12\u221202:00").toString()).toBe(
+  //     "15:23:30.12"
+  //   );
+  // });
+  it("basic format", () => {
+    expect(PlainTime.from("152330").toString()).toBe("15:23:30");
+    expect(PlainTime.from("152330.1").toString()).toBe("15:23:30.1");
+    expect(PlainTime.from("152330-08").toString()).toBe("15:23:30");
+    expect(PlainTime.from("152330.1-08").toString()).toBe("15:23:30.1");
+    expect(PlainTime.from("152330-0800").toString()).toBe("15:23:30");
+    expect(PlainTime.from("152330.1-0800").toString()).toBe("15:23:30.1");
+  });
+  it("mixture of basic and extended format", () => {
+    expect(PlainTime.from("1976-11-18T152330.1+00:00").toString()).toBe(
+      "15:23:30.1"
+    );
+    expect(PlainTime.from("19761118T15:23:30.1+00:00").toString()).toBe(
+      "15:23:30.1"
+    );
+    expect(PlainTime.from("1976-11-18T15:23:30.1+0000").toString()).toBe(
+      "15:23:30.1"
+    );
+    expect(PlainTime.from("1976-11-18T152330.1+0000").toString()).toBe(
+      "15:23:30.1"
+    );
+    expect(PlainTime.from("19761118T15:23:30.1+0000").toString()).toBe(
+      "15:23:30.1"
+    );
+    expect(PlainTime.from("19761118T152330.1+00:00").toString()).toBe(
+      "15:23:30.1"
+    );
+    expect(PlainTime.from("19761118T152330.1+0000").toString()).toBe(
+      "15:23:30.1"
+    );
+    expect(PlainTime.from("+001976-11-18T152330.1+00:00").toString()).toBe(
+      "15:23:30.1"
+    );
+    expect(PlainTime.from("+0019761118T15:23:30.1+00:00").toString()).toBe(
+      "15:23:30.1"
+    );
+    expect(PlainTime.from("+001976-11-18T15:23:30.1+0000").toString()).toBe(
+      "15:23:30.1"
+    );
+    expect(PlainTime.from("+001976-11-18T152330.1+0000").toString()).toBe(
+      "15:23:30.1"
+    );
+    expect(PlainTime.from("+0019761118T15:23:30.1+0000").toString()).toBe(
+      "15:23:30.1"
+    );
+    expect(PlainTime.from("+0019761118T152330.1+00:00").toString()).toBe(
+      "15:23:30.1"
+    );
+    expect(PlainTime.from("+0019761118T152330.1+0000").toString()).toBe(
+      "15:23:30.1"
+    );
+  });
+  it("optional parts", () => {
+    expect(PlainTime.from("15").toString()).toBe("15:00:00");
+  });
+  it("no junk at end of string", () => {
+    expect(() => {
+      PlainTime.from("15:23:30.100junk");
+    }).toThrow();
+  });
+  // it("options may only be an object or undefined", () => {
+  //   [null, 1, "hello", true, Symbol("foo"), 1n].forEach((badOptions) =>
+  //     throws(() => PlainTime.from({ hour: 12 }, badOptions), TypeError)
+  //   );
+  //   [{}, () => {}, undefined].forEach((options) =>
+  //     expect(PlainTime.from({ hour: 12 }, options)).toBe("12:00:00")
+  //   );
+  // });
+  // describe("Overflow", () => {
+  //   const bad = { nanosecond: 1000 };
+  //   it("reject", () =>
+  //     throws(() => PlainTime.from(bad, { overflow: "reject" }), RangeError));
+  //   it("constrain", () => {
+  //     expect(PlainTime.from(bad)).toBe("00:00:00.000000999");
+  //     expect(PlainTime.from(bad, { overflow: "constrain" })).toBe(
+  //       "00:00:00.000000999"
+  //     );
+  //   });
+  //   it("throw on bad overflow", () => {
+  //     [new PlainTime(15), { hour: 15 }, "15:00"].forEach((input) => {
+  //       ["", "CONSTRAIN", "balance", 3, null].forEach((overflow) =>
+  //         throws(() => PlainTime.from(input, { overflow }), RangeError)
+  //       );
+  //     });
+  //   });
+  //   const leap = { hour: 23, minute: 59, second: 60 };
+  //   it("reject leap second", () =>
+  //     throws(() => PlainTime.from(leap, { overflow: "reject" }), RangeError));
+  //   it("constrain leap second", () =>
+  //     expect(PlainTime.from(leap)).toBe("23:59:59"));
+  //   it("constrain has no effect on invalid ISO string", () => {
+  //     throws(
+  //       () => PlainTime.from("24:60", { overflow: "constrain" }),
+  //       RangeError
+  //     );
+  //   });
+  // });
+  // it("object must contain at least one correctly-spelled property", () => {
+  //   throws(() => PlainTime.from({}), TypeError);
+  //   throws(() => PlainTime.from({ minutes: 12 }), TypeError);
+  // });
+  // it("incorrectly-spelled properties are ignored", () => {
+  //   expect(PlainTime.from({ minutes: 1, hour: 1 })).toBe("01:00:00");
+  // });
+});

--- a/assembly/__tests__/plaintime.spec.ts
+++ b/assembly/__tests__/plaintime.spec.ts
@@ -1,0 +1,165 @@
+import { Duration, DurationLike } from "../duration";
+import { PlainTime } from "../plaintime";
+
+let time: PlainTime;
+
+describe("Construction", () => {
+  describe("complete", () => {
+    time = new PlainTime(15, 23, 30, 123, 456, 789);
+    it("time.hour is 15", () => {
+      expect(time.hour).toBe(15);
+    });
+    it("time.minute is 23", () => {
+      expect(time.minute).toBe(23);
+    });
+    it("time.second is 30", () => {
+      expect(time.second).toBe(30);
+    });
+    it("time.millisecond is 123", () => {
+      expect(time.millisecond).toBe(123);
+    });
+    it("time.microsecond is 456", () => {
+      expect(time.microsecond).toBe(456);
+    });
+    it("time.nanosecond is 789", () => {
+      expect(time.nanosecond).toBe(789);
+    });
+    // it("time.calendar.id is iso8601", () =>
+    //   expect(time.calendar.id).toBe("iso8601"));
+    // it("`${time}` is 15:23:30.123456789", () =>
+    //   expect(`${time}`).toBe("15:23:30.123456789"));
+  });
+  describe("missing nanosecond", () => {
+    time = new PlainTime(15, 23, 30, 123, 456);
+    it("time.hour is 15", () => {
+      expect(time.hour).toBe(15);
+    });
+    it("time.minute is 23", () => {
+      expect(time.minute).toBe(23);
+    });
+    it("time.second is 30", () => {
+      expect(time.second).toBe(30);
+    });
+    it("time.millisecond is 123", () => {
+      expect(time.millisecond).toBe(123);
+    });
+    it("time.microsecond is 456", () => {
+      expect(time.microsecond).toBe(456);
+    });
+    it("time.nanosecond is 0", () => {
+      expect(time.nanosecond).toBe(0);
+    });
+    // it("`${time}` is 15:23:30.123456", () => {
+    //   expect(`${time}`).toBe("15:23:30.123456");
+    // });
+  });
+  describe("missing microsecond", () => {
+    time = new PlainTime(15, 23, 30, 123);
+    it("time.hour is 15", () => {
+      expect(time.hour).toBe(15);
+    });
+    it("time.minute is 23", () => {
+      expect(time.minute).toBe(23);
+    });
+    it("time.second is 30", () => {
+      expect(time.second).toBe(30);
+    });
+    it("time.millisecond is 123", () => {
+      expect(time.millisecond).toBe(123);
+    });
+    it("time.microsecond is 0", () => {
+      expect(time.microsecond).toBe(0);
+    });
+    it("time.nanosecond is 0", () => {
+      expect(time.nanosecond).toBe(0);
+    });
+    // it("`${time}` is 15:23:30.123", () => {
+    //   expect(`${time}`).toBe("15:23:30.123");
+    // });
+  });
+  describe("missing millisecond", () => {
+    time = new PlainTime(15, 23, 30);
+    it("time.hour is 15", () => {
+      expect(time.hour).toBe(15);
+    });
+    it("time.minute is 23", () => {
+      expect(time.minute).toBe(23);
+    });
+    it("time.second is 30", () => {
+      expect(time.second).toBe(30);
+    });
+    it("time.millisecond is 0", () => {
+      expect(time.millisecond).toBe(0);
+    });
+    it("time.microsecond is 0", () => {
+      expect(time.microsecond).toBe(0);
+    });
+    it("time.nanosecond is 0", () => {
+      expect(time.nanosecond).toBe(0);
+    });
+    // it("`${time}` is 15:23:30", () => equal(`${time}`, "15:23:30"));
+  });
+  describe("missing second", () => {
+    time = new PlainTime(15, 23);
+    it("time.hour is 15", () => {
+      expect(time.hour).toBe(15);
+    });
+    it("time.minute is 23", () => {
+      expect(time.minute).toBe(23);
+    });
+    it("time.second is 0", () => {
+      expect(time.second).toBe(0);
+    });
+    it("time.millisecond is 0", () => {
+      expect(time.millisecond).toBe(0);
+    });
+    it("time.microsecond is 0", () => {
+      expect(time.microsecond).toBe(0);
+    });
+    it("time.nanosecond is 0", () => {
+      expect(time.nanosecond).toBe(0);
+    });
+    // it("`${time}` is 15:23:00", () => equal(`${time}`, "15:23:00"));
+  });
+  describe("missing minute", () => {
+    const time = new PlainTime(15);
+    // it("`${time}` is 15:00:00", () => equal(`${time}`, "15:00:00"));
+  });
+  describe("missing all parameters", () => {
+    const time = new PlainTime();
+    // it("`${time}` is 00:00:00", () => equal(`${time}`, "00:00:00"));
+  });
+});
+
+// describe('Time.compare() works', () => {
+//   const t1 = PlainTime.from('08:44:15.321');
+//   const t2 = PlainTime.from('14:23:30.123');
+//   it('equal', () => equal(PlainTime.compare(t1, t1), 0));
+//   it('smaller/larger', () => equal(PlainTime.compare(t1, t2), -1));
+//   it('larger/smaller', () => equal(PlainTime.compare(t2, t1), 1));
+//   it('casts first argument', () => {
+//     equal(PlainTime.compare({ hour: 16, minute: 34 }, t2), 1);
+//     equal(PlainTime.compare('16:34', t2), 1);
+//   });
+//   it('casts second argument', () => {
+//     equal(PlainTime.compare(t1, { hour: 16, minute: 34 }), -1);
+//     equal(PlainTime.compare(t1, '16:34'), -1);
+//   });
+//   it('object must contain at least one correctly-spelled property', () => {
+//     throws(() => PlainTime.compare({ hours: 16 }, t2), TypeError);
+//     throws(() => PlainTime.compare(t1, { hours: 16 }), TypeError);
+//   });
+// });
+// describe('time.equals() works', () => {
+//   const t1 = PlainTime.from('08:44:15.321');
+//   const t2 = PlainTime.from('14:23:30.123');
+//   it('equal', () => assert(t1.equals(t1)));
+//   it('unequal', () => assert(!t1.equals(t2)));
+//   it('casts argument', () => {
+//     assert(t1.equals('08:44:15.321'));
+//     assert(t1.equals({ hour: 8, minute: 44, second: 15, millisecond: 321 }));
+//   });
+//   it('object must contain at least one correctly-spelled property', () => {
+//     throws(() => t1.equals({ hours: 8 }), TypeError);
+//   });
+// });

--- a/assembly/__tests__/plaintime.spec.ts
+++ b/assembly/__tests__/plaintime.spec.ts
@@ -132,6 +132,70 @@ describe("Construction", () => {
   });
 });
 
+describe(".with manipulation", () => {
+  time = new PlainTime(15, 23, 30, 123, 456, 789);
+  it("time.with({ hour: 3 } works", () => {
+    expect(time.with({ hour: 3 }).toString()).toBe("03:23:30.123456789");
+  });
+  it("time.with({ minute: 3 } works", () => {
+    expect(time.with({ minute: 3 }).toString()).toBe("15:03:30.123456789");
+  });
+  it("time.with({ second: 3 } works", () => {
+    expect(time.with({ second: 3 }).toString()).toBe("15:23:03.123456789");
+  });
+  it("time.with({ millisecond: 3 } works", () => {
+    expect(time.with({ millisecond: 3 }).toString()).toBe("15:23:30.003456789");
+  });
+  it("time.with({ microsecond: 3 } works", () => {
+    expect(time.with({ microsecond: 3 }).toString()).toBe("15:23:30.123003789");
+  });
+  it("time.with({ nanosecond: 3 } works", () => {
+    expect(time.with({ nanosecond: 3 }).toString()).toBe("15:23:30.123456003");
+  });
+  it("time.with({ minute: 8, nanosecond: 3 } works", () => {
+    expect(time.with({ minute: 8, nanosecond: 3 }).toString()).toBe(
+      "15:08:30.123456003"
+    );
+  });
+  // it("invalid overflow", () => {
+  //   ["", "CONSTRAIN", "balance", 3, null].forEach((overflow) =>
+  //     throws(() => time.with({ hour: 3 }, { overflow }), RangeError)
+  //   );
+  // });
+  // it("options may only be an object or undefined", () => {
+  //   [null, 1, "hello", true, Symbol("foo"), 1n].forEach((badOptions) =>
+  //     throws(() => time.with({ hour: 3 }, badOptions), TypeError)
+  //   );
+  //   [{}, () => {}, undefined].forEach((options) =>
+  //     expect(time.with({ hour: 3 }, options).toString()).toBe(
+  //       "03:23:30.123456789"
+  //     )
+  //   );
+  // });
+  // it("object must contain at least one correctly-spelled property", () => {
+  //   throws(() => time.with({}), TypeError);
+  //   throws(() => time.with({ minutes: 12 }), TypeError);
+  // });
+  // it("incorrectly-spelled properties are ignored", () => {
+  //   expect(time.with({ minutes: 1, hour: 1 }).toString()).toBe(
+  //     "01:23:30.123456789"
+  //   );
+  // });
+  // it("time.with(string) throws", () => {
+  //   throws(() => time.with("18:05:42.577"), TypeError);
+  //   throws(() => time.with("2019-05-17T18:05:42.577"), TypeError);
+  //   throws(() => time.with("2019-05-17T18:05:42.577Z"), TypeError);
+  //   throws(() => time.with("2019-05-17"), TypeError);
+  //   throws(() => time.with("42"), TypeError);
+  // // });
+  // it("throws with calendar property", () => {
+  //   throws(() => time.with({ hour: 21, calendar: "iso8601" }), TypeError);
+  // });
+  // it("throws with timeZone property", () => {
+  //   throws(() => time.with({ hour: 21, timeZone: "UTC" }), TypeError);
+  // });
+});
+
 describe("Time.compare() works", () => {
   t1 = PlainTime.from("08:44:15.321");
   t2 = PlainTime.from("14:23:30.123");

--- a/assembly/__tests__/plaintime.spec.ts
+++ b/assembly/__tests__/plaintime.spec.ts
@@ -233,6 +233,7 @@ describe("time.toPlainDateTime() works", () => {
 describe("Time.compare() works", () => {
   t1 = PlainTime.from("08:44:15.321");
   t2 = PlainTime.from("14:23:30.123");
+
   it("equal", () => {
     expect(PlainTime.compare(t1, t1)).toBe(0);
   });
@@ -279,14 +280,14 @@ describe("time.add() works", () => {
   it(time.toString() + ".add({ hours: 16 })", () => {
     expect(
       time
-        .add<DurationLike>({ hours: 16 })
+        .add({ hours: 16 })
         .toString()
     ).toBe("07:23:30.123456789");
   });
   it(time.toString() + ".add({ minutes: 45 })", () => {
     expect(
       time
-        .add<DurationLike>({ minutes: 45 })
+        .add({ minutes: 45 })
         .toString()
     ).toBe("16:08:30.123456789");
   });
@@ -294,24 +295,24 @@ describe("time.add() works", () => {
     // https://github.com/ColinEberhardt/assemblyscript-temporal/pull/25#issuecomment-812995856
     expect(
       time
-        .add<DurationLike>({ nanoseconds: 300 })
+        .add({ nanoseconds: 300 })
         .toString()
     ).toBe("15:23:30.123457089");
   });
   it("symmetric with regard to negative durations", () => {
     expect(
       PlainTime.from<string>("07:23:30.123456789")
-        .add<DurationLike>({ hours: -16 })
+        .add({ hours: -16 })
         .toString()
     ).toBe("15:23:30.123456789");
     expect(
       PlainTime.from<string>("16:08:30.123456789")
-        .add<DurationLike>({ minutes: -45 })
+        .add({ minutes: -45 })
         .toString()
     ).toBe("15:23:30.123456789");
     expect(
       PlainTime.from<string>("15:23:30.123457089")
-        .add<DurationLike>({ nanoseconds: -300 })
+        .add({ nanoseconds: -300 })
         .toString()
     ).toBe("15:23:30.123456789");
   });
@@ -373,74 +374,74 @@ describe("time.subtract() works", () => {
   it(time.toString() + ".subtract({ hours: 16 })", () => {
     expect(
       time
-        .subtract<DurationLike>({ hours: 16 })
+        .subtract({ hours: 16 })
         .toString()
     ).toBe("23:23:30.123456789");
   });
   it(time.toString() + ".subtract({ minutes: 45 })", () => {
     expect(
       time
-        .subtract<DurationLike>({ minutes: 45 })
+        .subtract({ minutes: 45 })
         .toString()
     ).toBe("14:38:30.123456789");
   });
   it(time.toString() + ".subtract({ seconds: 45 })", () => {
     expect(
       time
-        .subtract<DurationLike>({ seconds: 45 })
+        .subtract({ seconds: 45 })
         .toString()
     ).toBe("15:22:45.123456789");
   });
   it(time.toString() + ".subtract({ milliseconds: 800 })", () => {
     expect(
       time
-        .subtract<DurationLike>({ milliseconds: 800 })
+        .subtract({ milliseconds: 800 })
         .toString()
     ).toBe("15:23:29.323456789");
   });
   it(time.toString() + ".subtract({ microseconds: 800 })", () => {
     expect(
       time
-        .subtract<DurationLike>({ microseconds: 800 })
+        .subtract({ microseconds: 800 })
         .toString()
     ).toBe("15:23:30.122656789");
   });
   it(time.toString() + ".subtract({ nanoseconds: 800 })", () => {
     expect(
       time
-        .subtract<DurationLike>({ nanoseconds: 800 })
+        .subtract({ nanoseconds: 800 })
         .toString()
     ).toBe("15:23:30.123455989");
   });
   it("symmetric with regard to negative durations", () => {
     expect(
       PlainTime.from("23:23:30.123456789")
-        .subtract<DurationLike>({ hours: -16 })
+        .subtract({ hours: -16 })
         .toString()
     ).toBe("15:23:30.123456789");
     expect(
       PlainTime.from("14:38:30.123456789")
-        .subtract<DurationLike>({ minutes: -45 })
+        .subtract({ minutes: -45 })
         .toString()
     ).toBe("15:23:30.123456789");
     expect(
       PlainTime.from("15:22:45.123456789")
-        .subtract<DurationLike>({ seconds: -45 })
+        .subtract({ seconds: -45 })
         .toString()
     ).toBe("15:23:30.123456789");
     expect(
       PlainTime.from("15:23:29.323456789")
-        .subtract<DurationLike>({ milliseconds: -800 })
+        .subtract({ milliseconds: -800 })
         .toString()
     ).toBe("15:23:30.123456789");
     expect(
       PlainTime.from("15:23:30.122656789")
-        .subtract<DurationLike>({ microseconds: -800 })
+        .subtract({ microseconds: -800 })
         .toString()
     ).toBe("15:23:30.123456789");
     expect(
       PlainTime.from("15:23:30.123455989")
-        .subtract<DurationLike>({ nanoseconds: -800 })
+        .subtract({ nanoseconds: -800 })
         .toString()
     ).toBe("15:23:30.123456789");
   });
@@ -454,17 +455,17 @@ describe("time.subtract() works", () => {
   it("ignores higher units", () => {
     expect(
       time
-        .subtract<DurationLike>({ days: 1 })
+        .subtract({ days: 1 })
         .toString()
     ).toBe("15:23:30.123456789");
     expect(
       time
-        .subtract<DurationLike>({ months: 1 })
+        .subtract({ months: 1 })
         .toString()
     ).toBe("15:23:30.123456789");
     expect(
       time
-        .subtract<DurationLike>({ years: 1 })
+        .subtract({ years: 1 })
         .toString()
     ).toBe("15:23:30.123456789");
   });

--- a/assembly/__tests__/plaintime.spec.ts
+++ b/assembly/__tests__/plaintime.spec.ts
@@ -281,9 +281,11 @@ describe("time.until() works", () => {
   t1 = PlainTime.from("10:23:15");
   t2 = PlainTime.from("17:15:57");
   it("the default largest unit is at least hours", () => {
-    expect(t1.until(t2).toString()).toBe("PT6H52M42S");
+    // changing to 2S to 2.0S to follow AS behavior.
+    // see https://github.com/ColinEberhardt/assemblyscript-temporal/pull/25#issuecomment-813415799
+    expect(t1.until(t2).toString()).toBe("PT6H52M42.0S");
     // expect(t1.until(t2, { largestUnit: "auto" }).toString()).toBe( "PT6H52M42S");
-    expect(t1.until(t2, TimeComponent.hours).toString()).toBe("PT6H52M42S");
+    expect(t1.until(t2, TimeComponent.hours).toString()).toBe("PT6H52M42.0S");
   });
   it("higher units are not allowed", () => {
     expect(() => {
@@ -300,8 +302,10 @@ describe("time.until() works", () => {
     }).toThrow();
   });
   it("can return lower units", () => {
-    expect(t1.until(t2, TimeComponent.minutes).toString()).toBe("PT412M42S");
-    expect(t1.until(t2, TimeComponent.seconds).toString()).toBe("PT24762S");
+    // changing to 2S to 2.0S to follow AS behavior.
+    // see https://github.com/ColinEberhardt/assemblyscript-temporal/pull/25#issuecomment-813415799
+    expect(t1.until(t2, TimeComponent.minutes).toString()).toBe("PT412M42.0S");
+    expect(t1.until(t2, TimeComponent.seconds).toString()).toBe("PT24762.0S");
   });
   it("can return subseconds", () => {
     t3 = t2.add({

--- a/assembly/__tests__/plaintime.spec.ts
+++ b/assembly/__tests__/plaintime.spec.ts
@@ -1,8 +1,13 @@
 import { Duration, DurationLike } from "../duration";
+import { PlainDate } from "../plaindate";
 import { PlainDateTime } from "../plaindatetime";
 import { PlainTime, TimeLike } from "../plaintime";
 
-let time: PlainTime, t1: PlainTime, t2: PlainTime, t3: PlainTime;
+let time: PlainTime,
+  t1: PlainTime,
+  t2: PlainTime,
+  t3: PlainTime,
+  dt: PlainDateTime;
 
 describe("Construction", () => {
   describe("complete", () => {
@@ -193,6 +198,35 @@ describe(".with manipulation", () => {
   // });
   // it("throws with timeZone property", () => {
   //   throws(() => time.with({ hour: 21, timeZone: "UTC" }), TypeError);
+  // });
+});
+
+describe("time.toPlainDateTime() works", () => {
+  time = PlainTime.from("11:30:23.123456789");
+  dt = time.toPlainDateTime({ year: 1976, month: 11, day: 18 });
+  it("with no argument", () => {
+    expect(time.toPlainDateTime().toString()).toBe(
+      "0-00-00T11:30:23.123456789"
+    );
+  });
+  it("returns a Temporal.PlainDateTime", () => {
+    assert(dt instanceof PlainDateTime);
+  });
+  it("combines the date and time", () => {
+    expect(dt.toString()).toBe("1976-11-18T11:30:23.123456789");
+  });
+  it("casts argument date like", () => {
+    expect(
+      time.toPlainDateTime({ year: 1976, month: 11, day: 18 }).toString()
+    ).toBe("1976-11-18T11:30:23.123456789");
+  });
+  xit("casts argument string like", () => {
+    // expect(time.toPlainDateTime("1976-11-18").toString()).toBe(
+    //   "1976-11-18T11:30:23.123456789"
+    // );
+  });
+  // it("object must contain at least the required properties", () => {
+  //   throws(() => time.toPlainDateTime({ year: 1976 }), TypeError);
   // });
 });
 

--- a/assembly/__tests__/plaintime.spec.ts
+++ b/assembly/__tests__/plaintime.spec.ts
@@ -281,11 +281,9 @@ describe("time.until() works", () => {
   t1 = PlainTime.from("10:23:15");
   t2 = PlainTime.from("17:15:57");
   it("the default largest unit is at least hours", () => {
-    // changing to 2S to 2.0S to follow AS behavior.
-    // see https://github.com/ColinEberhardt/assemblyscript-temporal/pull/25#issuecomment-813415799
-    expect(t1.until(t2).toString()).toBe("PT6H52M42.0S");
+    expect(t1.until(t2).toString()).toBe("PT6H52M42S");
     // expect(t1.until(t2, { largestUnit: "auto" }).toString()).toBe( "PT6H52M42S");
-    expect(t1.until(t2, TimeComponent.hours).toString()).toBe("PT6H52M42.0S");
+    expect(t1.until(t2, TimeComponent.hours).toString()).toBe("PT6H52M42S");
   });
   it("higher units are not allowed", () => {
     expect(() => {
@@ -302,10 +300,8 @@ describe("time.until() works", () => {
     }).toThrow();
   });
   it("can return lower units", () => {
-    // changing to 2S to 2.0S to follow AS behavior.
-    // see https://github.com/ColinEberhardt/assemblyscript-temporal/pull/25#issuecomment-813415799
-    expect(t1.until(t2, TimeComponent.minutes).toString()).toBe("PT412M42.0S");
-    expect(t1.until(t2, TimeComponent.seconds).toString()).toBe("PT24762.0S");
+    expect(t1.until(t2, TimeComponent.minutes).toString()).toBe("PT412M42S");
+    expect(t1.until(t2, TimeComponent.seconds).toString()).toBe("PT24762S");
   });
   it("can return subseconds", () => {
     t3 = t2.add({
@@ -744,9 +740,9 @@ describe("time.since() works", () => {
   t1 = PlainTime.from("10:23:15");
   t2 = PlainTime.from("17:15:57");
   it("the default largest unit is at least hours", () => {
-    expect(t2.since(t1).toString()).toBe("PT6H52M42.0S");
+    expect(t2.since(t1).toString()).toBe("PT6H52M42S");
     // expect(t2.since(t1, largestUnit: 'auto)", 'PT6H52M42S');
-    expect(t2.since(t1, TimeComponent.hours).toString()).toBe("PT6H52M42.0S");
+    expect(t2.since(t1, TimeComponent.hours).toString()).toBe("PT6H52M42S");
   });
   it("higher units are not allowed", () => {
     expect(() => {
@@ -763,8 +759,8 @@ describe("time.since() works", () => {
     }).toThrow();
   });
   it("can return lower units", () => {
-    expect(t2.since(t1, TimeComponent.minutes).toString()).toBe("PT412M42.0S");
-    expect(t2.since(t1, TimeComponent.seconds).toString()).toBe("PT24762.0S");
+    expect(t2.since(t1, TimeComponent.minutes).toString()).toBe("PT412M42S");
+    expect(t2.since(t1, TimeComponent.seconds).toString()).toBe("PT24762S");
   });
   it("can return subseconds", () => {
     t3 = t2.add({ milliseconds: 250, microseconds: 250, nanoseconds: 250 });

--- a/assembly/__tests__/plaintime.spec.ts
+++ b/assembly/__tests__/plaintime.spec.ts
@@ -179,8 +179,6 @@ describe("time.equals() works", () => {
 describe("time.add() works", () => {
   time = new PlainTime(15, 23, 30, 123, 456, 789);
   it(time.toString() + ".add({ hours: 16 })", () => {
-    log(time.second);
-
     expect(
       time
         .add<DurationLike>({ hours: 16 })
@@ -194,7 +192,8 @@ describe("time.add() works", () => {
         .toString()
     ).toBe("16:08:30.123456789");
   });
-  it(time.toString() + ".add({ nanoseconds: 300 })", () => {
+  xit(time.toString() + ".add({ nanoseconds: 300 })", () => {
+    // https://github.com/ColinEberhardt/assemblyscript-temporal/pull/25#issuecomment-812995856
     expect(
       time
         .add<DurationLike>({ nanoseconds: 300 })

--- a/assembly/duration.ts
+++ b/assembly/duration.ts
@@ -60,14 +60,14 @@ export class Duration {
   // P1Y1M1DT1H1M1.1S
   toString(): string {
     const date =
-      toString(this.years, "Y") +
-      toString(this.months, "M") +
-      toString(this.weeks, "W") +
-      toString(this.days, "D");
+      toString(abs(this.years), "Y") +
+      toString(abs(this.months), "M") +
+      toString(abs(this.weeks), "W") +
+      toString(abs(this.days), "D");
 
     const time =
-      toString(this.hours, "H") +
-      toString(this.minutes, "M") +
+      toString(abs(this.hours), "H") +
+      toString(abs(this.minutes), "M") +
       toString(
         // sort in ascending order for better sum precision
         f64(this.nanoseconds) / 1000000000.0 +

--- a/assembly/duration.ts
+++ b/assembly/duration.ts
@@ -85,5 +85,11 @@ export class Duration {
 }
 
 function toString<T extends number>(value: T, suffix: string): string {
-  return value ? value.toString() + suffix : "";
+  return value
+    ? (isFloat<T>() ? stringify(value) : value.toString()) + suffix
+    : "";
+}
+
+function stringify(value: f64): string {
+  return F64.isSafeInteger(value) ? i64(value).toString() : value.toString();
 }

--- a/assembly/plaindatetime.ts
+++ b/assembly/plaindatetime.ts
@@ -68,10 +68,12 @@ export class PlainDateTime {
     );
     const match = dateRegex.exec(date);
     if (match != null) {
-      const fraction = match.matches[7] + "000000000";
+      // see https://github.com/ColinEberhardt/assemblyscript-regex/issues/38
+      const fraction = (
+        match.matches[7] != "" ? match.matches[7] : match.matches[18]
+      ) + "000000000";
       return new PlainDateTime(
         I32.parseInt(match.matches[1]),
-        // see https://github.com/ColinEberhardt/assemblyscript-regex/issues/38
         I32.parseInt(
           match.matches[2] != "" ? match.matches[2] : match.matches[19]
         ),
@@ -79,8 +81,8 @@ export class PlainDateTime {
           match.matches[3] != "" ? match.matches[3] : match.matches[20]
         ),
         I32.parseInt(match.matches[4]),
-        I32.parseInt(match.matches[5]),
-        I32.parseInt(match.matches[6]),
+        I32.parseInt(match.matches[5] != "" ? match.matches[5]: match.matches[16]),
+        I32.parseInt(match.matches[6] != "" ? match.matches[6]: match.matches[17]),
         I32.parseInt(fraction.substring(0, 3)),
         I32.parseInt(fraction.substring(3, 6)),
         I32.parseInt(fraction.substring(6, 9))

--- a/assembly/plaindatetime.ts
+++ b/assembly/plaindatetime.ts
@@ -2,6 +2,7 @@ import { RegExp } from "../node_modules/assemblyscript-regex/assembly/index";
 
 import { Duration, DurationLike } from "./duration";
 import { Overflow, TimeComponent } from "./enums";
+import { PlainTime } from "./plaintime";
 import {
   dayOfWeek,
   dayOfYear,
@@ -190,6 +191,17 @@ export class PlainDateTime {
           ).toString().substring(1)
         : ""
       )
+    );
+  }
+
+  toPlainTime(): PlainTime {
+    return new PlainTime(
+      this.hour,
+      this.minute,
+      this.second,
+      this.millisecond,
+      this.microsecond,
+      this.nanosecond
     );
   }
 

--- a/assembly/plaindatetime.ts
+++ b/assembly/plaindatetime.ts
@@ -67,6 +67,7 @@ export class PlainDateTime {
     );
     const match = dateRegex.exec(date);
     if (match != null) {
+      const fraction = match.matches[7] + "000000000";
       return new PlainDateTime(
         I32.parseInt(match.matches[1]),
         // see https://github.com/ColinEberhardt/assemblyscript-regex/issues/38
@@ -79,9 +80,9 @@ export class PlainDateTime {
         I32.parseInt(match.matches[4]),
         I32.parseInt(match.matches[5]),
         I32.parseInt(match.matches[6]),
-        I32.parseInt(match.matches[7].substring(0, 3)),
-        I32.parseInt(match.matches[7].substring(3, 6)),
-        I32.parseInt(match.matches[7].substring(6, 9))
+        I32.parseInt(fraction.substring(0, 3)),
+        I32.parseInt(fraction.substring(3, 6)),
+        I32.parseInt(fraction.substring(6, 9))
       );
     }
     throw new RangeError("invalid ISO 8601 string: " + date);

--- a/assembly/plaintime.ts
+++ b/assembly/plaintime.ts
@@ -11,6 +11,7 @@ import { DurationLike } from "./duration";
 import { TimeComponent } from "./enums";
 import { RegExp } from "../node_modules/assemblyscript-regex/assembly/index";
 import { PlainDateTime } from "./plaindatetime";
+import { DateLike } from "./plaindate";
 export class TimeLike {
   hour: i32 = -1;
   minute: i32 = -1;
@@ -93,8 +94,7 @@ export class PlainTime {
           ? match.matches[4]
           : match.matches[7] != ""
           ? match.matches[7]
-          : match.matches[15]) +
-        "000000000";
+          : match.matches[15]) + "000000000";
       millisecond = I32.parseInt(fraction.substring(0, 3));
       microsecond = I32.parseInt(fraction.substring(3, 6));
       nanosecond = I32.parseInt(fraction.substring(6, 9));
@@ -131,7 +131,7 @@ export class PlainTime {
         } else if (time instanceof TimeLike) {
           return this.fromTimeLike(time);
         } else if (time instanceof PlainDateTime) {
-          return this.fromPlainDateTime(time)
+          return this.fromPlainDateTime(time);
         }
       }
       throw new TypeError("invalid time type");
@@ -190,6 +190,22 @@ export class PlainTime {
     );
   }
 
+  toPlainDateTime(
+    dateLike: DateLike = { year: 0, month: 0, day: 0 }
+  ): PlainDateTime {
+    return new PlainDateTime(
+      coalesce(dateLike.year, 0),
+      coalesce(dateLike.month, 0),
+      coalesce(dateLike.day, 0),
+      this.hour,
+      this.minute,
+      this.second,
+      this.millisecond,
+      this.microsecond,
+      this.nanosecond
+    );
+  }
+
   equals(other: PlainTime): bool {
     if (this === other) return true;
     return (
@@ -227,8 +243,8 @@ export class PlainTime {
     const duration =
       durationToAdd instanceof DurationLike
         ? durationToAdd.toDuration()
-        // @ts-ignore TS2352
-        : (durationToAdd as Duration);
+        : // @ts-ignore TS2352
+          (durationToAdd as Duration);
 
     const balancedDuration = balanceDuration(
       duration.days,
@@ -268,8 +284,8 @@ export class PlainTime {
     const duration =
       durationToSubtract instanceof DurationLike
         ? durationToSubtract.toDuration()
-        // @ts-ignore TS2352
-        : (durationToSubtract as Duration);
+        : // @ts-ignore TS2352
+          (durationToSubtract as Duration);
 
     const balancedDuration = balanceDuration(
       duration.days,

--- a/assembly/plaintime.ts
+++ b/assembly/plaintime.ts
@@ -252,6 +252,46 @@ export class PlainTime {
     );
   }
 
+  since(
+    other: PlainTime,
+    largestUnit: TimeComponent = TimeComponent.hours
+  ): Duration {
+    if (
+      largestUnit == TimeComponent.years ||
+      largestUnit == TimeComponent.months ||
+      largestUnit == TimeComponent.weeks ||
+      largestUnit == TimeComponent.days
+    ) {
+      throw new RangeError("higher units are not allowed");
+    }
+
+    let diffTime = differenceTime(
+      this.hour,
+      this.minute,
+      this.second,
+      this.millisecond,
+      this.microsecond,
+      this.nanosecond,
+      other.hour,
+      other.minute,
+      other.second,
+      other.millisecond,
+      other.microsecond,
+      other.nanosecond,
+    )
+    return balanceDuration(
+      // diffTime.days,
+      0,
+      -diffTime.hours,
+      -diffTime.minutes,
+      -diffTime.seconds,
+      -diffTime.milliseconds,
+      -diffTime.microseconds,
+      -diffTime.nanoseconds,
+      largestUnit
+    );
+  }
+
   equals(other: PlainTime): bool {
     if (this === other) return true;
     return (

--- a/assembly/plaintime.ts
+++ b/assembly/plaintime.ts
@@ -243,7 +243,7 @@ export class PlainTime {
     return ord(a.nanosecond, b.nanosecond);
   }
 
-  add<T>(durationToAdd: T): PlainTime {
+  add<T = DurationLike>(durationToAdd: T): PlainTime {
     const duration =
       durationToAdd instanceof DurationLike
         ? durationToAdd.toDuration()
@@ -284,7 +284,7 @@ export class PlainTime {
     );
   }
 
-  subtract<T>(durationToSubtract: T): PlainTime {
+  subtract<T = DurationLike>(durationToSubtract: T): PlainTime {
     const duration =
       durationToSubtract instanceof DurationLike
         ? durationToSubtract.toDuration()

--- a/assembly/plaintime.ts
+++ b/assembly/plaintime.ts
@@ -166,7 +166,7 @@ export class PlainTime {
       toPaddedString(this.minute) +
       ":" +
       toPaddedString(this.second) +
-      (this.nanosecond != 0 || this.microsecond != 0 || this.millisecond != 0
+      ((this.nanosecond | this.microsecond | this.millisecond) != 0
         ? (
             f64(this.nanosecond) / 1_000_000_000.0 +
             f64(this.microsecond) / 1_000_000.0 +
@@ -215,8 +215,8 @@ export class PlainTime {
     const duration =
       durationToAdd instanceof DurationLike
         ? durationToAdd.toDuration()
-        : // @ts-ignore TS2352
-          (durationToAdd as Duration);
+        // @ts-ignore TS2352
+        : (durationToAdd as Duration);
 
     const balancedDuration = balanceDuration(
       duration.days,
@@ -256,8 +256,8 @@ export class PlainTime {
     const duration =
       durationToSubtract instanceof DurationLike
         ? durationToSubtract.toDuration()
-        : // @ts-ignore TS2352
-          (durationToSubtract as Duration);
+        // @ts-ignore TS2352
+        : (durationToSubtract as Duration);
 
     const balancedDuration = balanceDuration(
       duration.days,

--- a/assembly/plaintime.ts
+++ b/assembly/plaintime.ts
@@ -190,13 +190,17 @@ export class PlainTime {
     );
   }
 
-  toPlainDateTime(
-    dateLike: DateLike = { year: 0, month: 0, day: 0 }
-  ): PlainDateTime {
+  toPlainDateTime(dateLike: DateLike | null = null): PlainDateTime {
+    let year = 0, month = 0, day = 0;
+    if (dateLike !== null) {
+       year  = coalesce(dateLike.year, 0);
+       month = coalesce(dateLike.month, 0);
+       day   = coalesce(dateLike.day, 0);
+    }
     return new PlainDateTime(
-      coalesce(dateLike.year, 0),
-      coalesce(dateLike.month, 0),
-      coalesce(dateLike.day, 0),
+      year,
+      month,
+      day,
       this.hour,
       this.minute,
       this.second,
@@ -243,8 +247,8 @@ export class PlainTime {
     const duration =
       durationToAdd instanceof DurationLike
         ? durationToAdd.toDuration()
-        : // @ts-ignore TS2352
-          (durationToAdd as Duration);
+        // @ts-ignore TS2352
+        : (durationToAdd as Duration);
 
     const balancedDuration = balanceDuration(
       duration.days,
@@ -284,8 +288,8 @@ export class PlainTime {
     const duration =
       durationToSubtract instanceof DurationLike
         ? durationToSubtract.toDuration()
-        : // @ts-ignore TS2352
-          (durationToSubtract as Duration);
+        // @ts-ignore TS2352
+        : (durationToSubtract as Duration);
 
     const balancedDuration = balanceDuration(
       duration.days,

--- a/assembly/plaintime.ts
+++ b/assembly/plaintime.ts
@@ -1,9 +1,33 @@
-import { sign, ord, checkRange } from "./utils";
+import { sign, ord, checkRange, balanceDuration, addTime } from "./utils";
+import { DurationLike } from "./duration"
+import { TimeComponent } from "./enums";
+
+
+export class TimeLike {
+  hour: i32 = 0;
+  minute: i32 = 0;
+  second: i32 = 0;
+  millisecond: i32 = 0;
+  microsecond: i32 = 0;
+  nanosecond: i32 = 0;
+}
 
 export class PlainTime {
 
   @inline
   static fromPlainTime(time: PlainTime): PlainTime {
+    return new PlainTime(
+      time.hour,
+      time.minute,
+      time.second,
+      time.millisecond,
+      time.microsecond,
+      time.nanosecond
+    );
+  }
+
+  @inline
+  static fromTimeLike(time: TimeLike): PlainTime {
     return new PlainTime(
       time.hour,
       time.minute,
@@ -64,4 +88,87 @@ export class PlainTime {
 
     return ord(a.nanosecond, b.nanosecond);
   }
+
+  add<T>(durationToAdd: T): PlainTime {
+    const duration =
+      durationToAdd instanceof DurationLike
+        ? durationToAdd.toDuration()
+        : // @ts-ignore TS2352
+          (durationToAdd as Duration);
+
+    const balancedDuration = balanceDuration(
+      duration.days,
+      duration.hours,
+      duration.minutes,
+      duration.seconds,
+      duration.milliseconds,
+      duration.microseconds,
+      duration.nanoseconds,
+      TimeComponent.nanoseconds
+    )
+    const newTime = addTime(
+      this.hour,
+      this.minute,
+      this.second,
+      this.millisecond,
+      this.microsecond,
+      this.nanosecond,
+      duration.hours,
+      duration.minutes,
+      duration.seconds,
+      duration.milliseconds,
+      duration.microseconds,
+      balancedDuration.nanoseconds
+    )
+    return new PlainTime(
+      newTime.hour,
+      newTime.minute,
+      newTime.second,
+      newTime.millisecond,
+      newTime.microsecond,
+      newTime.nanosecond
+    )
+  }
+
+  subtract<T>(durationToSubtract: T): PlainTime {
+    const duration =
+    durationToSubtract instanceof DurationLike
+        ? durationToSubtract.toDuration()
+        : // @ts-ignore TS2352
+          (durationToSubtract as Duration);
+
+    const balancedDuration = balanceDuration(
+      duration.days,
+      duration.hours,
+      duration.minutes,
+      duration.seconds,
+      duration.milliseconds,
+      duration.microseconds,
+      duration.nanoseconds,
+      TimeComponent.nanoseconds
+    )
+    const newTime = addTime(
+      this.hour,
+      this.minute,
+      this.second,
+      this.millisecond,
+      this.microsecond,
+      this.nanosecond,
+      -duration.hours,
+      -duration.minutes,
+      -duration.seconds,
+      -duration.milliseconds,
+      -duration.microseconds,
+      -balancedDuration.nanoseconds
+    )
+    return new PlainTime(
+      newTime.hour,
+      newTime.minute,
+      newTime.second,
+      newTime.millisecond,
+      newTime.microsecond,
+      newTime.nanosecond
+    )
+  }
+
 }

--- a/assembly/plaintime.ts
+++ b/assembly/plaintime.ts
@@ -5,18 +5,19 @@ import {
   balanceDuration,
   addTime,
   toPaddedString,
+  coalesce,
 } from "./utils";
 import { DurationLike } from "./duration";
 import { TimeComponent } from "./enums";
 import { RegExp } from "../node_modules/assemblyscript-regex/assembly/index";
 import { PlainDateTime } from "./plaindatetime";
 export class TimeLike {
-  hour: i32 = 0;
-  minute: i32 = 0;
-  second: i32 = 0;
-  millisecond: i32 = 0;
-  microsecond: i32 = 0;
-  nanosecond: i32 = 0;
+  hour: i32 = -1;
+  minute: i32 = -1;
+  second: i32 = -1;
+  millisecond: i32 = -1;
+  microsecond: i32 = -1;
+  nanosecond: i32 = -1;
 }
 
 export class PlainTime {
@@ -47,12 +48,12 @@ export class PlainTime {
   @inline
   static fromTimeLike(time: TimeLike): PlainTime {
     return new PlainTime(
-      time.hour,
-      time.minute,
-      time.second,
-      time.millisecond,
-      time.microsecond,
-      time.nanosecond
+      coalesce(time.hour, 0),
+      coalesce(time.minute, 0),
+      coalesce(time.second, 0),
+      coalesce(time.millisecond, 0),
+      coalesce(time.microsecond, 0),
+      coalesce(time.nanosecond, 0)
     );
   }
 
@@ -156,6 +157,17 @@ export class PlainTime {
       )
     )
       throw new RangeError("invalid plain time");
+  }
+
+  with(timeLike: TimeLike): PlainTime {
+    return new PlainTime(
+      coalesce(timeLike.hour, this.hour),
+      coalesce(timeLike.minute, this.minute),
+      coalesce(timeLike.second, this.second),
+      coalesce(timeLike.millisecond, this.millisecond),
+      coalesce(timeLike.microsecond, this.microsecond),
+      coalesce(timeLike.nanosecond, this.nanosecond)
+    );
   }
 
   toString(): string {

--- a/assembly/plaintime.ts
+++ b/assembly/plaintime.ts
@@ -6,9 +6,11 @@ import {
   addTime,
   toPaddedString,
   coalesce,
+  differenceTime,
+  regulateTime,
 } from "./utils";
-import { DurationLike } from "./duration";
-import { TimeComponent } from "./enums";
+import { Duration, DurationLike } from "./duration";
+import { Overflow, TimeComponent } from "./enums";
 import { RegExp } from "../node_modules/assemblyscript-regex/assembly/index";
 import { PlainDateTime } from "./plaindatetime";
 import { DateLike } from "./plaindate";
@@ -250,16 +252,6 @@ export class PlainTime {
         // @ts-ignore TS2352
         : (durationToAdd as Duration);
 
-    const balancedDuration = balanceDuration(
-      duration.days,
-      duration.hours,
-      duration.minutes,
-      duration.seconds,
-      duration.milliseconds,
-      duration.microseconds,
-      duration.nanoseconds,
-      TimeComponent.nanoseconds
-    );
     const newTime = addTime(
       this.hour,
       this.minute,
@@ -272,15 +264,25 @@ export class PlainTime {
       duration.seconds,
       duration.milliseconds,
       duration.microseconds,
-      balancedDuration.nanoseconds
+      duration.nanoseconds
     );
-    return new PlainTime(
+
+    const regulatedTime = regulateTime(
       newTime.hour,
       newTime.minute,
       newTime.second,
       newTime.millisecond,
       newTime.microsecond,
-      newTime.nanosecond
+      newTime.nanosecond,
+      Overflow.Reject
+    )
+    return new PlainTime(
+      regulatedTime.hour,
+      regulatedTime.minute,
+      regulatedTime.second,
+      regulatedTime.millisecond,
+      regulatedTime.microsecond,
+      regulatedTime.nanosecond
     );
   }
 
@@ -291,16 +293,6 @@ export class PlainTime {
         // @ts-ignore TS2352
         : (durationToSubtract as Duration);
 
-    const balancedDuration = balanceDuration(
-      duration.days,
-      duration.hours,
-      duration.minutes,
-      duration.seconds,
-      duration.milliseconds,
-      duration.microseconds,
-      duration.nanoseconds,
-      TimeComponent.nanoseconds
-    );
     const newTime = addTime(
       this.hour,
       this.minute,
@@ -313,15 +305,25 @@ export class PlainTime {
       -duration.seconds,
       -duration.milliseconds,
       -duration.microseconds,
-      -balancedDuration.nanoseconds
+      -duration.nanoseconds
     );
-    return new PlainTime(
+
+    const regulatedTime = regulateTime(
       newTime.hour,
       newTime.minute,
       newTime.second,
       newTime.millisecond,
       newTime.microsecond,
-      newTime.nanosecond
+      newTime.nanosecond,
+      Overflow.Reject
+    )
+    return new PlainTime(
+      regulatedTime.hour,
+      regulatedTime.minute,
+      regulatedTime.second,
+      regulatedTime.millisecond,
+      regulatedTime.microsecond,
+      regulatedTime.nanosecond
     );
   }
 }

--- a/assembly/plaintime.ts
+++ b/assembly/plaintime.ts
@@ -212,6 +212,46 @@ export class PlainTime {
     );
   }
 
+  until(
+    other: PlainTime,
+    largestUnit: TimeComponent = TimeComponent.hours
+  ): Duration {
+    if (
+      largestUnit == TimeComponent.years ||
+      largestUnit == TimeComponent.months ||
+      largestUnit == TimeComponent.weeks ||
+      largestUnit == TimeComponent.days
+    ) {
+      throw new RangeError("higher units are not allowed");
+    }
+
+    let diffTime = differenceTime(
+      this.hour,
+      this.minute,
+      this.second,
+      this.millisecond,
+      this.microsecond,
+      this.nanosecond,
+      other.hour,
+      other.minute,
+      other.second,
+      other.millisecond,
+      other.microsecond,
+      other.nanosecond,
+    )
+    return balanceDuration(
+      // diffTime.days,
+      0,
+      diffTime.hours,
+      diffTime.minutes,
+      diffTime.seconds,
+      diffTime.milliseconds,
+      diffTime.microseconds,
+      diffTime.nanoseconds,
+      largestUnit
+    );
+  }
+
   equals(other: PlainTime): bool {
     if (this === other) return true;
     return (

--- a/assembly/utils.ts
+++ b/assembly/utils.ts
@@ -186,7 +186,7 @@ function balanceDate(year: i32, month: i32, day: i32): YMD {
 export function sign<T extends number>(x: T): T {
   // x < 0 ? -1 : 1   ->   x >> 31 | 1
   // @ts-ignore
-  return (x >> (sizeof<T>() * 4 - 1)) | 1;
+  return (x >> (sizeof<T>() * 8 - 1)) | 1;
 }
 
 // @ts-ignore: decorator
@@ -395,24 +395,28 @@ export function balanceDuration(
     nanoseconds as i64
   );
 
+  let nanosecondsI64: i64 = 0;
+  let microsecondsI64: i64 = 0;
+  let millisecondsI64: i64 = 0;
+  let secondsI64: i64 = 0;
+  let minutesI64: i64 = 0;
+  let hoursI64: i64 = 0;
+  let daysI64: i64 = 0;
+
   if (
     largestUnit >= TimeComponent.years &&
     largestUnit <= TimeComponent.days
   ) {
     const _ES$NanosecondsToDays = nanosecondsToDays(durationNs);
-    days        = _ES$NanosecondsToDays.days;
-    nanoseconds = _ES$NanosecondsToDays.nanoseconds;
+    daysI64        = _ES$NanosecondsToDays.days;
+    nanosecondsI64 = _ES$NanosecondsToDays.nanoseconds;
   } else {
-    days = 0;
+    daysI64 = 0;
+    nanosecondsI64 = durationNs
   }
 
-  const sig = sign(nanoseconds);
-  nanoseconds = abs(nanoseconds);
-  microseconds = 0;
-  milliseconds = 0;
-  seconds = 0;
-  minutes = 0;
-  hours = 0;
+  const sig = sign(nanosecondsI64);
+  nanosecondsI64 = abs(nanosecondsI64);
 
   switch (largestUnit) {
     case TimeComponent.years:
@@ -420,58 +424,58 @@ export function balanceDuration(
     case TimeComponent.weeks:
     case TimeComponent.days:
     case TimeComponent.hours:
-      microseconds = nanoseconds / 1000;
-      nanoseconds  = nanoseconds % 1000;
+      microsecondsI64 = nanosecondsI64 / 1000;
+      nanosecondsI64  = nanosecondsI64 % 1000;
 
-      milliseconds = microseconds / 1000;
-      microseconds = microseconds % 1000;
+      millisecondsI64 = microsecondsI64 / 1000;
+      microsecondsI64 = microsecondsI64 % 1000;
 
-      seconds      = milliseconds / 1000;
-      milliseconds = milliseconds % 1000;
+      secondsI64      = millisecondsI64 / 1000;
+      millisecondsI64 = millisecondsI64 % 1000;
 
-      minutes = seconds / 60;
-      seconds = seconds % 60;
+      minutesI64 = secondsI64 / 60;
+      secondsI64 = secondsI64 % 60;
 
-      hours   = minutes / 60;
-      minutes = minutes % 60;
+      hoursI64   = minutesI64 / 60;
+      minutesI64 = minutesI64 % 60;
       break;
 
     case TimeComponent.minutes:
-      microseconds = nanoseconds / 1000;
-      nanoseconds  = nanoseconds % 1000;
+      microsecondsI64 = nanosecondsI64 / 1000;
+      nanosecondsI64  = nanosecondsI64 % 1000;
 
-      milliseconds = microseconds / 1000;
-      microseconds = microseconds % 1000;
+      millisecondsI64 = microsecondsI64 / 1000;
+      microsecondsI64 = microsecondsI64 % 1000;
 
-      seconds      = milliseconds / 1000;
-      milliseconds = milliseconds % 1000;
+      secondsI64      = millisecondsI64 / 1000;
+      millisecondsI64 = millisecondsI64 % 1000;
 
-      minutes = seconds / 60;
-      seconds = seconds % 60;
+      minutesI64 = secondsI64 / 60;
+      secondsI64 = secondsI64 % 60;
       break;
 
     case TimeComponent.seconds:
-      microseconds = nanoseconds / 1000;
-      nanoseconds  = nanoseconds % 1000;
+      microsecondsI64 = nanosecondsI64 / 1000;
+      nanosecondsI64  = nanosecondsI64 % 1000;
 
-      milliseconds = microseconds / 1000;
-      microseconds = microseconds % 1000;
+      millisecondsI64 = microsecondsI64 / 1000;
+      microsecondsI64 = microsecondsI64 % 1000;
 
-      seconds      = milliseconds / 1000;
-      milliseconds = milliseconds % 1000;
+      secondsI64      = millisecondsI64 / 1000;
+      millisecondsI64 = millisecondsI64 % 1000;
       break;
 
     case TimeComponent.milliseconds:
-      microseconds = nanoseconds / 1000;
-      nanoseconds  = nanoseconds % 1000;
+      microsecondsI64 = nanosecondsI64 / 1000;
+      nanosecondsI64  = nanosecondsI64 % 1000;
 
-      milliseconds = microseconds / 1000;
-      microseconds = microseconds % 1000;
+      millisecondsI64 = microsecondsI64 / 1000;
+      microsecondsI64 = microsecondsI64 % 1000;
       break;
 
     case TimeComponent.microseconds:
-      microseconds = nanoseconds / 1000;
-      nanoseconds  = nanoseconds % 1000;
+      microsecondsI64 = nanosecondsI64 / 1000;
+      nanosecondsI64  = nanosecondsI64 % 1000;
       break;
 
     case TimeComponent.nanoseconds:
@@ -482,13 +486,13 @@ export function balanceDuration(
     0,
     0,
     0,
-    days,
-    hours * sig,
-    minutes * sig,
-    seconds * sig,
-    milliseconds * sig,
-    microseconds * sig,
-    nanoseconds * sig
+    i32(daysI64),
+    i32(hoursI64 * sig),
+    i32(minutesI64 * sig),
+    i32(secondsI64 * sig),
+    i32(millisecondsI64 * sig),
+    i32(microsecondsI64 * sig),
+    i32(nanosecondsI64 * sig)
   );
 }
 

--- a/assembly/utils.ts
+++ b/assembly/utils.ts
@@ -415,7 +415,7 @@ export function balanceDuration(
     nanosecondsI64 = durationNs
   }
 
-  const sig = sign(nanosecondsI64);
+  const sig = i32(sign(nanosecondsI64));
   nanosecondsI64 = abs(nanosecondsI64);
 
   switch (largestUnit) {
@@ -487,12 +487,12 @@ export function balanceDuration(
     0,
     0,
     i32(daysI64),
-    i32(hoursI64 * sig),
-    i32(minutesI64 * sig),
-    i32(secondsI64 * sig),
-    i32(millisecondsI64 * sig),
-    i32(microsecondsI64 * sig),
-    i32(nanosecondsI64 * sig)
+    i32(hoursI64) * sig,
+    i32(minutesI64) * sig,
+    i32(secondsI64) * sig,
+    i32(millisecondsI64) * sig,
+    i32(microsecondsI64) * sig,
+    i32(nanosecondsI64) * sig
   );
 }
 

--- a/assembly/utils.ts
+++ b/assembly/utils.ts
@@ -670,6 +670,63 @@ export function differenceDate(
   }
 }
 
+// https://github.com/tc39/proposal-temporal/blob/515ee6e339bb4a1d3d6b5a42158f4de49f9ed953/polyfill/lib/ecmascript.mjs#L2874-L2910
+export function differenceTime(
+  h1: i32,
+  min1: i32,
+  s1: i32,
+  ms1: i32,
+  µs1:i32,
+  ns1: i32,
+  h2: i32,
+  min2: i32,
+  s2: i32,
+  ms2: i32,
+  µs2: i32,
+  ns2: i32
+): Duration {
+  let hours = h2 - h1;
+  let minutes = min2 - min1;
+  let seconds = s2 - s1;
+  let milliseconds = ms2 - ms1;
+  let microseconds = µs2 - µs1;
+  let nanoseconds = ns2 - ns1;
+
+  const sign = durationSign(
+    0, 
+    0, 
+    0, 
+    0, 
+    hours,
+    minutes,
+    seconds,
+    milliseconds,
+    microseconds,
+    nanoseconds
+  );
+  hours *= sign;
+  minutes *= sign;
+  seconds *= sign;
+  milliseconds *= sign;
+  microseconds *= sign;
+  nanoseconds *= sign;
+
+  let balancedTime = balanceTime(hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
+
+  return new Duration(
+    0,
+    0,
+    0,
+    balancedTime.deltaDays * sign,
+    balancedTime.hour * sign,
+    balancedTime.minute * sign,
+    balancedTime.second * sign,
+    balancedTime.millisecond * sign,
+    balancedTime.microsecond * sign,
+    balancedTime.nanosecond * sign
+  )
+
+}
 
 export function epochFromParts(
   year: i32,

--- a/assembly/utils.ts
+++ b/assembly/utils.ts
@@ -750,7 +750,7 @@ export function addDateTime(
   };
 }
 
-function addTime(
+export function addTime(
   hour: i32,
   minute: i32,
   second: i32,

--- a/assembly/utils.ts
+++ b/assembly/utils.ts
@@ -27,6 +27,15 @@ export class YM {
   month: i32;
 }
 
+export class PT {
+  hour: i32;
+  minute: i32;
+  second: i32;
+  millisecond: i32;
+  microsecond: i32;
+  nanosecond: i32;
+}
+
 export class DT {
   year: i32;
   month: i32;
@@ -748,6 +757,60 @@ export function addDateTime(
     microsecond,
     nanosecond
   };
+}
+
+// https://github.com/tc39/proposal-temporal/blob/515ee6e339bb4a1d3d6b5a42158f4de49f9ed953/polyfill/lib/ecmascript.mjs#L2676-L2684
+export function constrainTime(
+  hour: i32,
+  minute: i32,
+  second: i32,
+  millisecond: i32,
+  microsecond: i32,
+  nanosecond: i32,
+): PT {
+  hour = clamp(hour, 0, 23);
+  minute = clamp(minute, 0, 59);
+  second = clamp(second, 0, 59);
+  millisecond = clamp(millisecond, 0, 999);
+  microsecond = clamp(microsecond, 0, 999);
+  nanosecond = clamp(nanosecond, 0, 999);
+  return { hour, minute, second, millisecond, microsecond, nanosecond };
+}
+
+// https://github.com/tc39/proposal-temporal/blob/515ee6e339bb4a1d3d6b5a42158f4de49f9ed953/polyfill/lib/ecmascript.mjs#L407-L422
+export function regulateTime(
+  hour: i32,
+  minute: i32,
+  second: i32,
+  millisecond: i32,
+  microsecond: i32,
+  nanosecond: i32,
+  overflow: Overflow
+): PT {
+  switch (overflow) {
+    case Overflow.Reject:
+      // rejectTime(hour, minute, second, millisecond, microsecond, nanosecond);
+      break;
+
+    case Overflow.Constrain:
+      const time = constrainTime(
+        hour,
+        minute,
+        second,
+        millisecond,
+        microsecond,
+        nanosecond
+      );
+      hour = time.hour;
+      minute = time.minute;
+      second = time.second;
+      millisecond = time.millisecond;
+      microsecond = time.microsecond;
+      nanosecond = time.nanosecond;
+      break;
+  }
+
+  return { hour, minute, second, millisecond, microsecond, nanosecond };
 }
 
 export function addTime(


### PR DESCRIPTION
Part of #21

- [ ] PlainTime
  - [x] compare (https://github.com/ColinEberhardt/assemblyscript-temporal/pull/8)
  - [x] equals (https://github.com/ColinEberhardt/assemblyscript-temporal/pull/8)
  - [x] from
  - [x] add
  - [x] subtract
  - [x] toString
  - [x] with
  - [x] until
  - [x] since
  - [ ] round
  - [ ] toJSON
  - [ ] valueOf
  - [x] toPlainDateTime


Other fixes include in PR
- fix PlainDateTime.fromString for "1976-11-18T15:23:30.1Z" family              [[2d0abd5](https://github.com/ColinEberhardt/assemblyscript-temporal/pull/25/commits/2d0abd54b9dd64c74271f1393d87db3d4286c59a)]
- fix PlainDateTime.fromString for "1976-11-18T152330.1+00:00" family      [[73b57ec](https://github.com/ColinEberhardt/assemblyscript-temporal/pull/25/commits/73b57ec507ace84a40fc05fc6e57d70ce2a1af78)]
- fix #29 : balanceDuration() for largestUnit greater than Days                 [[5c36d22](https://github.com/ColinEberhardt/assemblyscript-temporal/pull/25/commits/5c36d2263079106350570bb89c3c9f5d07756c71)]
- fix Duration.toString() for negative values [[6cc1621](https://github.com/ColinEberhardt/assemblyscript-temporal/pull/25/commits/6cc16218dee06247993293e70fe657478de05468)]
- fix trailing zero in Duration.toString()
