### PR TITLE
Implement Date.UTC

### DIFF
--- a/assembly/__tests__/date.spec.ts
+++ b/assembly/__tests__/date.spec.ts
@@ -218,3 +218,71 @@ describe("toString", () => {
     expect(date.toISOString()).toBe("2009-01-06T08:40:31.020Z");
   });
 });
+
+describe("Date.UTC", () => {
+  it("epoch", () => {
+    expect(Date.UTC(1970)).toBe(0);
+  });
+
+  describe("two digit years", () => {
+    it("0", () => {
+      expect(Date.UTC(0)).toBe(Date.UTC(1900));
+    });
+
+    it("99", () => {
+      expect(Date.UTC(99)).toBe(Date.UTC(1999));
+    });
+  });
+
+  it("defaults to month=0", () => {
+    expect(Date.UTC(2001)).toBe(Date.UTC(2001, 0));
+  });
+
+  it("defaults to date=1", () => {
+    expect(Date.UTC(2001, 0)).toBe(Date.UTC(2001, 0, 1));
+  });
+
+  it("defaults to hours=0", () => {
+    expect(Date.UTC(2001, 0, 1)).toBe(Date.UTC(2001, 0, 1, 0));
+  });
+
+  it("defaults to minutes=0", () => {
+    expect(Date.UTC(2001, 0, 1, 0)).toBe(Date.UTC(2001, 0, 1, 0, 0));
+  });
+
+  it("defaults to seconds=0", () => {
+    expect(Date.UTC(2001, 0, 1, 0, 0)).toBe(Date.UTC(2001, 0, 1, 0, 0, 0));
+  });
+
+  it("defaults to milliseconds=0", () => {
+    expect(Date.UTC(2001, 0, 1, 0, 0, 0)).toBe(
+      Date.UTC(2001, 0, 1, 0, 0, 0, 0)
+    );
+  });
+
+  // Taken from https://github.com/v8/v8/blob/master/test/mjsunit/date.js
+
+  it("8639999999999999", () => {
+    expect(Date.UTC(275760, 8, 12, 23, 59, 59, 999)).toBe(8639999999999999);
+  });
+
+  it("8640000000000000", () => {
+    expect(Date.UTC(275760, 8, 13)).toBe(8640000000000000);
+  });
+
+  it("-8639999999999999", () => {
+    expect(Date.UTC(-271821, 3, 20, 0, 0, 0, 1)).toBe(-8639999999999999);
+  });
+
+  it("-8640000000000000", () => {
+    expect(Date.UTC(-271821, 3, 20)).toBe(-8640000000000000);
+  });
+
+  it("obscure date values", () => {
+    expect(Date.UTC(1970, 0, 1 + 100000001, -24)).toBe(8640000000000000);
+  });
+
+  it("obscure date values", () => {
+    expect(Date.UTC(1970, 0, 1 - 100000001, 24)).toBe(-8640000000000000);
+  });
+});

--- a/assembly/date.ts
+++ b/assembly/date.ts
@@ -1,8 +1,13 @@
 // TODO: This functionality will likely be moved into the AssemblyScript Standard Library
 // https://github.com/AssemblyScript/assemblyscript/pull/1768
 
-import { YMD } from "./utils";
-import { MILLIS_PER_DAY, MILLIS_PER_HOUR, MILLIS_PER_MINUTE, MILLIS_PER_SECOND } from "./constants";
+import { checkRange, YMD } from "./utils";
+import {
+  MILLIS_PER_DAY,
+  MILLIS_PER_HOUR,
+  MILLIS_PER_MINUTE,
+  MILLIS_PER_SECOND
+} from "./constants";
 
 export class Date {
   epochMilliseconds: i64;
@@ -48,6 +53,28 @@ export class Date {
         minute * MILLIS_PER_MINUTE +
         second * MILLIS_PER_SECOND +
         millisecond
+    );
+  }
+
+  // https://tc39.es/ecma262/#sec-date.utc
+  static UTC(
+    year: i32,
+    month: i32 = 0,
+    date: i32 = 1,
+    hours: i32 = 0,
+    minutes: i32 = 0,
+    seconds: i32 = 0,
+    ms: i32 = 0
+  ): i64 {
+    if (checkRange(year, 0, 99)) {
+      year += 1900;
+    }
+    return (
+      <i64>days_from_civil(year, month + 1, date) * MILLIS_PER_DAY +
+      hours * MILLIS_PER_HOUR +
+      minutes * MILLIS_PER_MINUTE +
+      seconds * MILLIS_PER_SECOND +
+      ms
     );
   }
 


### PR DESCRIPTION
`Date.UTC` is used in the tests for `Instant`. So why not implement it.

I referenced the Date spec and used the test cases from v8.

The cast to `i64` was required since otherwise it would overflow while still being `i32`.