### PR TITLE
decorate all global variables with @lazy

### DIFF
--- a/assembly/constants.ts
+++ b/assembly/constants.ts
@@ -1,6 +1,23 @@
+// @ts-ignore
+@lazy
 export const MILLIS_PER_DAY = 1_000 * 60 * 60 * 24;
+
+// @ts-ignore
+@lazy
 export const MILLIS_PER_HOUR = 1_000 * 60 * 60;
+
+// @ts-ignore
+@lazy
 export const MILLIS_PER_MINUTE = 1_000 * 60;
+
+// @ts-ignore
+@lazy
 export const MILLIS_PER_SECOND = 1_000;
+
+// @ts-ignore
+@lazy
 export const MICROS_PER_SECOND = 1_000_000;
+
+// @ts-ignore
+@lazy
 export const NANOS_PER_SECOND = 1_000_000_000;

--- a/assembly/utils.ts
+++ b/assembly/utils.ts
@@ -11,9 +11,16 @@ import { Overflow, TimeComponent } from "./enums";
 import { MILLIS_PER_SECOND, NANOS_PER_SECOND } from "./constants";
 import { log } from "./env";
 
+// @ts-ignore
+@lazy
 const YEAR_MIN = -271821;
+
+// @ts-ignore
+@lazy
 const YEAR_MAX =  275760;
 
+// @ts-ignore
+@lazy
 let __null = false;
 
 // value objects - used in place of object literals


### PR DESCRIPTION
### Rationale
If Global variables in the library are not decorated with @lazy then they are compiled even if they aren't referenced.
So every wasm built will have the copy of those variables and state

See, [`empty.ts`](https://github.com/near/near-sdk-as/blob/master/simulator/assembly/__tests__/empty.ts) and its output wat in [this failing test log](https://github.com/near/near-sdk-as/runs/2317621869#step:5:548)

### Changes
Decorate all the global variables with `@lazy`