### PR TITLE
Fix instant

### DIFF
--- a/assembly/instant.ts
+++ b/assembly/instant.ts
@@ -47,7 +47,7 @@ export class Instant {
     return new Instant(nanos);
   }
 
-  constructor(public epochNanoseconds: i64) {}
+  constructor(public readonly epochNanoseconds: i64) {}
 
   @inline
   get epochMicroseconds(): i64 {

--- a/assembly/instant.ts
+++ b/assembly/instant.ts
@@ -112,8 +112,9 @@ export class Instant {
     return balancedDuration(0, 0, 0, 0, 0, 0, diffNanos, largestUnit);
   }
 
-  equals(other: Instant): boolean {
-    return this.epochNanoseconds == other.epochNanoseconds;
+  equals<T>(other: T): boolean {
+    const otherInstant = other instanceof Instant ? other : Instant.from(other);
+    return this.epochNanoseconds == otherInstant.epochNanoseconds;
   }
 
   @inline


### PR DESCRIPTION
According to the [spec](https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.equals) `Instant.equals` accepts any object convertible to `Instant`.

And `Instant.epochNanoseconds` is just a getter without a setter ([spec](https://tc39.es/proposal-temporal/#sec-get-temporal.instant.prototype.epochnanoseconds)), but since we use a property instead of an internal slot we have to make it `readonly`.