### PR TITLE
Refactor Duration.toString to fix issues

### DIFF
--- a/assembly/__tests__/duration.spec.ts
+++ b/assembly/__tests__/duration.spec.ts
@@ -245,6 +245,7 @@ describe("toString()", () => {
   it("supports nanosecond precision", () => {
     expect(`${Duration.from({ nanoseconds: -250 })}`).toBe("-PT0.00000025S");
     expect(`${Duration.from({ nanoseconds: -3500 })}`).toBe("-PT0.0000035S");
+    expect(`${Duration.from("P366DT0.000000001S")}`).toBe("P366DT0.000000001S");
   });
   it("negative sub-second units are balanced correctly", () => {
     expect(`${Duration.from({ milliseconds: -250 })}`).toBe("-PT0.25S");

--- a/assembly/__tests__/duration.spec.ts
+++ b/assembly/__tests__/duration.spec.ts
@@ -242,7 +242,7 @@ describe("toString()", () => {
       "PT123.5S"
     );
   });
-  xit("supports nanosecond precision", () => {
+  it("supports nanosecond precision", () => {
     expect(`${Duration.from({ nanoseconds: -250 })}`).toBe("-PT0.00000025S");
     expect(`${Duration.from({ nanoseconds: -3500 })}`).toBe("-PT0.0000035S");
   });

--- a/assembly/duration.ts
+++ b/assembly/duration.ts
@@ -314,17 +314,6 @@ export class Duration {
   }
 }
 
-function toString<T extends number>(value: T, suffix: string): string {
-  if (value) return (isFloat<T>() ? stringify(value) : value.toString()) + suffix;
-  return "";
-}
-
-// @ts-ignore: decorator
-@inline
-function stringify(value: f64): string {
-  return F64.isSafeInteger(value) ? i64(value).toString() : value.toString();
-}
-
 function totalDurationNanoseconds(
   days: i64,
   hours: i64,

--- a/assembly/duration.ts
+++ b/assembly/duration.ts
@@ -4,7 +4,6 @@ import { PlainDateTime } from "./plaindatetime";
 import { TimeComponent } from "./enums";
 import { coalesce, sign } from "./util";
 import {
-  MICROS_PER_SECOND,
   MILLIS_PER_SECOND,
   NANOS_PER_DAY,
   NANOS_PER_SECOND


### PR DESCRIPTION
There's probably a lot of room for improvement. (e.g. the `while` loop)

I tried to keep string operations as rare as possible.