### PR TITLE
fix: rename `now` to `Now`

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,12 +109,12 @@ duration2.toString(); // "P3DT10M"
 ```
 
 
-#### `now`
+#### `Now`
 
-The `now` object has several methods which give information about the current time and date.
+The `Now` object has several methods which give information about the current time and date.
 
 ```javascript
-dateTime = now.plainDateTimeISO();
+dateTime = Now.plainDateTimeISO();
 dateTime.toString(); // 2021-04-01T12:05:47.357
 ```
 

--- a/assembly/index.ts
+++ b/assembly/index.ts
@@ -5,5 +5,8 @@ export { PlainDate } from "./plaindate";
 export { PlainDateTime } from "./plaindatetime";
 export { Duration } from "./duration";
 export * from "./enums";
-export { now } from "./now";
+export { Now } from "./now";
 export { Instant } from "./instant";
+
+// @deprecated `now` is not a standard API use `Now` instead
+export { Now as now } from "./now";

--- a/assembly/now.ts
+++ b/assembly/now.ts
@@ -3,7 +3,7 @@ import { PlainDate } from "./plaindate";
 import { PlainTime } from "./plaintime";
 import { Instant } from "./instant";
 
-export class now {
+export class Now {
   static plainDateTimeISO(): PlainDateTime {
     const epochMillis = Date.now();
     const date = new Date(epochMillis);

--- a/development.md
+++ b/development.md
@@ -3,7 +3,7 @@
 This is a very large library, therefore a prioritised roadmap is important. The following is the rough priority order:
 
  1. Non-timezone aware classes, i.e. `PlainDate`, `PlainDateTime`, etc with a hard-coded Gregorian calendar.
- 2. Ancillary classes, i.e. `Instant`, `Duration` and `now`
+ 2. Ancillary classes, i.e. `Instant`, `Duration` and `Now`
  3. Time-zone aware classes, `TimeZone`, `ZonedDateTime`, etc
  4. Non gregorian calendar systems
 
@@ -338,7 +338,7 @@ General features
 
 - [ ] rounding and smallest unit behaviour
 
-#### now
+#### Now
 
 Methods
 - [ ] zonedDateTimeISO


### PR DESCRIPTION
- `now` renamed to `Now` since it is not a standard Temporal API.
- named export `now` deprecated in favour of `Now`